### PR TITLE
Implement [EntryPoint] attribute

### DIFF
--- a/src/Cle.Common/DiagnosticCode.cs
+++ b/src/Cle.Common/DiagnosticCode.cs
@@ -16,6 +16,8 @@
         ExpectedNamespaceName,
         InvalidNamespaceName,
 
+        ExpectedAttributeName,
+        AttributesOnlyApplicableToFunctions,
         ExpectedVisibilityModifier,
         ExpectedType,
         ExpectedFunctionName,
@@ -27,6 +29,7 @@
         ExpectedSemicolon,
         ExpectedClosingParen,
         ExpectedClosingBrace,
+        ExpectedClosingBracket,
 
         ExpectedStatement,
         ExpectedExpression,

--- a/src/Cle.Common/DiagnosticCode.cs
+++ b/src/Cle.Common/DiagnosticCode.cs
@@ -47,6 +47,10 @@
 
         TypeNotFound,
         MethodAlreadyDefined,
+        UnknownAttribute,
+        EntryPointMustBeDeclaredCorrectly,
+        NoEntryPointProvided,
+        MultipleEntryPointsProvided,
 
         TypeMismatch,
         IntegerConstantOutOfBounds,

--- a/src/Cle.Frontend/DiagnosticMessages.cs
+++ b/src/Cle.Frontend/DiagnosticMessages.cs
@@ -85,6 +85,14 @@ namespace Cle.Frontend
                     return $"Type {diagnostic.Actual} does not exist or is not visible in this file.";
                 case DiagnosticCode.MethodAlreadyDefined:
                     return $"Method {diagnostic.Actual} is already defined in this scope.";
+                case DiagnosticCode.UnknownAttribute:
+                    return $"Attribute {diagnostic.Actual} is not known by the compiler.";
+                case DiagnosticCode.EntryPointMustBeDeclaredCorrectly:
+                    return "A method marked as an entry point must return int32 and take no parameters.";
+                case DiagnosticCode.NoEntryPointProvided:
+                    return "The main module does not contain a method marked as the entry point.";
+                case DiagnosticCode.MultipleEntryPointsProvided:
+                    return "The main module already has an entry point.";
                 case DiagnosticCode.TypeMismatch:
                     return $"Expression is of type {diagnostic.Actual} but expected {diagnostic.Expected}.";
                 case DiagnosticCode.IntegerConstantOutOfBounds:

--- a/src/Cle.Frontend/DiagnosticMessages.cs
+++ b/src/Cle.Frontend/DiagnosticMessages.cs
@@ -30,7 +30,7 @@ namespace Cle.Frontend
                 case DiagnosticCode.InvalidNamespaceName:
                     return $"'{diagnostic.Actual}' is not a valid namespace name.";
                 case DiagnosticCode.ExpectedAttributeName:
-                    return $"Expected attribute name, read '{diagnostic.Actual}'";
+                    return $"Expected attribute name, read '{diagnostic.Actual}'.";
                 case DiagnosticCode.AttributesOnlyApplicableToFunctions:
                     return "Attributes can only be applied to functions.";
                 case DiagnosticCode.ExpectedVisibilityModifier:

--- a/src/Cle.Frontend/DiagnosticMessages.cs
+++ b/src/Cle.Frontend/DiagnosticMessages.cs
@@ -29,6 +29,10 @@ namespace Cle.Frontend
                     return $"Expected namespace name, read '{diagnostic.Actual}'.";
                 case DiagnosticCode.InvalidNamespaceName:
                     return $"'{diagnostic.Actual}' is not a valid namespace name.";
+                case DiagnosticCode.ExpectedAttributeName:
+                    return $"Expected attribute name, read '{diagnostic.Actual}'";
+                case DiagnosticCode.AttributesOnlyApplicableToFunctions:
+                    return "Attributes can only be applied to functions.";
                 case DiagnosticCode.ExpectedVisibilityModifier:
                     return $"Expected definition preceded by a visibility modifier, read '{diagnostic.Actual}'.";
                 case DiagnosticCode.ExpectedType:
@@ -49,6 +53,8 @@ namespace Cle.Frontend
                     return $"Expected ')', read '{diagnostic.Actual}'.";
                 case DiagnosticCode.ExpectedClosingBrace:
                     return $"Expected '}}', read '{diagnostic.Actual}'.";
+                case DiagnosticCode.ExpectedClosingBracket:
+                    return $"Expected ']', read '{diagnostic.Actual}'.";
                 case DiagnosticCode.ExpectedStatement:
                     return $"Expected statement, read '{diagnostic.Actual}'.";
                 case DiagnosticCode.ExpectedExpression:

--- a/src/Cle.Parser/Lexer.cs
+++ b/src/Cle.Parser/Lexer.cs
@@ -234,7 +234,8 @@ namespace Cle.Parser
                    character == (byte)'*' || character == (byte)'/' || 
                    character == (byte)';' ||
                    character == (byte)'(' || character == (byte)')' ||
-                   character == (byte)'{' || character == (byte)'}';
+                   character == (byte)'{' || character == (byte)'}' ||
+                   character == (byte)'[' || character == (byte)']';
         }
 
         private static TokenType ClassifyToken(ReadOnlySpan<byte> token)
@@ -278,6 +279,10 @@ namespace Cle.Parser
                         return TokenType.OpenBrace;
                     case (byte)'}':
                         return TokenType.CloseBrace;
+                    case (byte)'[':
+                        return TokenType.OpenBracket;
+                    case (byte)']':
+                        return TokenType.CloseBracket;
                 }
             }
 

--- a/src/Cle.Parser/SyntaxParser.cs
+++ b/src/Cle.Parser/SyntaxParser.cs
@@ -196,7 +196,10 @@ namespace Cle.Parser
             // TODO: Parameter lists
 
             // Eat the closing bracket
-            ExpectToken(TokenType.CloseBracket, DiagnosticCode.ExpectedClosingBracket);
+            if (!ExpectToken(TokenType.CloseBracket, DiagnosticCode.ExpectedClosingBracket))
+            {
+                return false;
+            }
 
             attribute = new AttributeSyntax(attributeName, startPosition);
             return true;

--- a/src/Cle.Parser/SyntaxTree/AttributeSyntax.cs
+++ b/src/Cle.Parser/SyntaxTree/AttributeSyntax.cs
@@ -1,0 +1,25 @@
+﻿using Cle.Common;
+using JetBrains.Annotations;
+
+namespace Cle.Parser.SyntaxTree
+{
+    /// <summary>
+    /// Syntax tree node for an attribute applied to a function.
+    /// </summary>
+    public sealed class AttributeSyntax : StatementSyntax
+    {
+        /// <summary>
+        /// Gets the name of the attribute.
+        /// </summary>
+        [NotNull]
+        public string Name { get; }
+
+        public AttributeSyntax(
+            [NotNull] string name,
+            TextPosition position)
+            : base(position)
+        {
+            Name = name;
+        }
+    }
+}

--- a/src/Cle.Parser/SyntaxTree/FunctionSyntax.cs
+++ b/src/Cle.Parser/SyntaxTree/FunctionSyntax.cs
@@ -1,4 +1,5 @@
-﻿using Cle.Common;
+﻿using System.Collections.Immutable;
+using Cle.Common;
 using JetBrains.Annotations;
 
 namespace Cle.Parser.SyntaxTree
@@ -28,6 +29,14 @@ namespace Cle.Parser.SyntaxTree
         public string ReturnTypeName { get; }
 
         /// <summary>
+        /// Gets the list of attributes applied to this function.
+        /// The list may be empty.
+        /// </summary>
+        [NotNull]
+        [ItemNotNull]
+        public ImmutableList<AttributeSyntax> Attributes { get; }
+
+        /// <summary>
         /// Gets the code block of this function.
         /// </summary>
         [NotNull]
@@ -37,6 +46,7 @@ namespace Cle.Parser.SyntaxTree
             [NotNull] string name,
             [NotNull] string returnType,
             Visibility visibility,
+            [NotNull, ItemNotNull] ImmutableList<AttributeSyntax> attributes,
             [NotNull] BlockSyntax block,
             TextPosition position)
             : base(position)
@@ -44,6 +54,7 @@ namespace Cle.Parser.SyntaxTree
             Name = name;
             ReturnTypeName = returnType;
             Visibility = visibility;
+            Attributes = attributes;
             Block = block;
         }
     }

--- a/src/Cle.Parser/TokenType.cs
+++ b/src/Cle.Parser/TokenType.cs
@@ -35,6 +35,8 @@
         CloseParen,
         OpenBrace,
         CloseBrace,
+        OpenBracket,
+        CloseBracket,
         EndOfFile,
     }
 }

--- a/src/Cle.SemanticAnalysis/MethodDeclaration.cs
+++ b/src/Cle.SemanticAnalysis/MethodDeclaration.cs
@@ -15,6 +15,11 @@ namespace Cle.SemanticAnalysis
         public int BodyIndex { get; }
 
         /// <summary>
+        /// If true, this method is the entry point for an executable application.
+        /// </summary>
+        public bool IsEntryPoint { get; }
+
+        /// <summary>
         /// Gets the return type of this method.
         /// </summary>
         [NotNull]
@@ -42,13 +47,15 @@ namespace Cle.SemanticAnalysis
             [NotNull] TypeDefinition returnType, 
             Visibility visibility,
             [NotNull] string definingFilename,
-            TextPosition sourcePosition)
+            TextPosition sourcePosition,
+            bool isEntryPoint)
         {
             BodyIndex = bodyIndex;
             ReturnType = returnType;
             Visibility = visibility;
             DefiningFilename = definingFilename;
             DefinitionPosition = sourcePosition;
+            IsEntryPoint = isEntryPoint;
         }
     }
 }

--- a/test/Cle.Compiler.UnitTests/CompilationTests.cs
+++ b/test/Cle.Compiler.UnitTests/CompilationTests.cs
@@ -261,7 +261,8 @@ namespace Cle.Compiler.UnitTests
         {
             var diagnostics = new SingleFileDiagnosticSink();
             diagnostics.Reset(".", filename);
-            var methodSyntax = new FunctionSyntax(methodName, "bool", visibility,
+            var methodSyntax = new FunctionSyntax(methodName, "bool", 
+                visibility, ImmutableList<AttributeSyntax>.Empty,
                 new BlockSyntax(ImmutableList<StatementSyntax>.Empty, default), default);
             var declaration = MethodCompiler.CompileDeclaration(methodSyntax, filename, 0, compilation, diagnostics);
 

--- a/test/Cle.Compiler.UnitTests/CompilationTests.cs
+++ b/test/Cle.Compiler.UnitTests/CompilationTests.cs
@@ -63,14 +63,15 @@ namespace Cle.Compiler.UnitTests
         }
 
         [Test]
-        public void AddMissingModuleError_adds_error()
+        public void AddModuleLevelDiagnostic_adds_error()
         {
             var compilation = new Compilation();
 
-            compilation.AddMissingModuleError("ModuleName");
+            compilation.AddModuleLevelDiagnostic(DiagnosticCode.ModuleNotFound, "ModuleName");
 
             Assert.That(compilation.HasErrors, Is.True);
             Assert.That(compilation.Diagnostics, Has.Exactly(1).Items);
+            Assert.That(compilation.Diagnostics[0].Code, Is.EqualTo(DiagnosticCode.ModuleNotFound));
             Assert.That(compilation.Diagnostics[0].Module, Is.EqualTo("ModuleName"));
             Assert.That(compilation.Diagnostics[0].Filename, Is.Null);
         }
@@ -251,6 +252,18 @@ namespace Cle.Compiler.UnitTests
             
             var method = new CompiledMethod();
             Assert.That(() => compilation.SetMethodBody(1, method), Throws.InstanceOf<ArgumentException>());
+        }
+
+        [Test]
+        public void TrySetEntryPointIndex_can_be_called_only_once()
+        {
+            var compilation = new Compilation();
+
+            Assert.That(compilation.EntryPointIndex, Is.EqualTo(-1));
+            Assert.That(compilation.TrySetEntryPointIndex(17), Is.True);
+            Assert.That(compilation.EntryPointIndex, Is.EqualTo(17));
+            Assert.That(compilation.TrySetEntryPointIndex(34), Is.False);
+            Assert.That(compilation.EntryPointIndex, Is.EqualTo(17));
         }
 
         private static MethodDeclaration CreateDeclaration(

--- a/test/Cle.Compiler.UnitTests/CompilerDriverTests.cs
+++ b/test/Cle.Compiler.UnitTests/CompilerDriverTests.cs
@@ -100,6 +100,52 @@ internal int32 IntFunction() {}";
             Assert.That(result.Diagnostics[0].Module, Is.EqualTo("."));
             Assert.That(result.Diagnostics[0].Filename, Is.EqualTo("file2.cle"));
         }
+        
+        [Test]
+        public void Compile_exits_if_main_module_provides_no_entry_point()
+        {
+            const string source1 = @"namespace Test;";
+            var fileProvider = new TestingSourceFileProvider();
+            fileProvider.Add(".", "main.cle", source1);
+
+            var result = CompilerDriver.Compile(".", new CompilationOptions(), fileProvider);
+
+            Assert.That(result.FailedCount, Is.EqualTo(1));
+            Assert.That(result.ModuleCount, Is.EqualTo(1));
+            Assert.That(result.SucceededCount, Is.EqualTo(0));
+
+            Assert.That(result.Diagnostics, Has.Exactly(1).Items);
+            Assert.That(result.Diagnostics[0].Code, Is.EqualTo(DiagnosticCode.NoEntryPointProvided));
+            Assert.That(result.Diagnostics[0].Module, Is.EqualTo("."));
+        }
+
+        // TODO: When the module system exists, a test should allow having entry points in separate modules
+        [Test]
+        public void Compile_exits_if_main_module_provides_multiple_entry_points()
+        {
+            const string source1 = @"namespace Test;
+[EntryPoint]
+private int32 Main() { return 0; }";
+            const string source2 = @"namespace Test::BetterFunctions;
+[EntryPoint]
+private int32 MuchBetterMain() { return 42; }";
+            var fileProvider = new TestingSourceFileProvider();
+            fileProvider.Add(".", "file1.cle", source1);
+            fileProvider.Add(".", "file2.cle", source2);
+
+            var result = CompilerDriver.Compile(".", new CompilationOptions(), fileProvider);
+
+            Assert.That(result.FailedCount, Is.EqualTo(1));
+            Assert.That(result.ModuleCount, Is.EqualTo(1));
+            Assert.That(result.SucceededCount, Is.EqualTo(0));
+
+            Assert.That(result.Diagnostics, Has.Exactly(1).Items);
+            Assert.That(result.Diagnostics[0].Code, Is.EqualTo(DiagnosticCode.MultipleEntryPointsProvided));
+            Assert.That(result.Diagnostics[0].Actual, Is.EqualTo("Test::BetterFunctions::MuchBetterMain"));
+            Assert.That(result.Diagnostics[0].Position.Line, Is.EqualTo(3));
+            Assert.That(result.Diagnostics[0].Module, Is.EqualTo("."));
+            Assert.That(result.Diagnostics[0].Filename, Is.EqualTo("file2.cle"));
+        }
 
         [Test]
         public void ParseModule_parses_single_file_successfully()

--- a/test/Cle.Parser.UnitTests/SyntaxParserTests/AttributeTests.cs
+++ b/test/Cle.Parser.UnitTests/SyntaxParserTests/AttributeTests.cs
@@ -1,0 +1,73 @@
+using Cle.Common;
+using NUnit.Framework;
+
+namespace Cle.Parser.UnitTests.SyntaxParserTests
+{
+    public class AttributeTests : SyntaxParserTestBase
+    {
+        [Test]
+        public void Two_attributes_without_parameters()
+        {
+            const string source = @"namespace Test;
+[Attribute1]
+[Attribute2]
+private void Function() {}";
+            var syntaxTree = ParseSourceWithoutDiagnostics(source);
+            Assert.That(syntaxTree.Functions, Has.Exactly(1).Items);
+            var function = syntaxTree.Functions[0];
+
+            Assert.That(function.Attributes, Has.Exactly(2).Items);
+            Assert.That(function.Attributes[0].Name, Is.EqualTo("Attribute1"));
+            Assert.That(function.Attributes[0].Position.Line, Is.EqualTo(2));
+            Assert.That(function.Attributes[1].Name, Is.EqualTo("Attribute2"));
+            Assert.That(function.Attributes[1].Position.Line, Is.EqualTo(3));
+            Assert.That(function.Position.Line, Is.EqualTo(4));
+        }
+
+        [Test]
+        public void Attribute_name_must_exist()
+        {
+            const string source = @"namespace Test;
+[]
+private void Function() {}";
+            var syntaxTree = ParseSource(source, out var diagnostics);
+
+            Assert.That(syntaxTree, Is.Null);
+            diagnostics.AssertDiagnosticAt(DiagnosticCode.ExpectedAttributeName, 2, 1).WithActual("]");
+        }
+
+        [Test]
+        public void Keyword_is_not_valid_attribute_name()
+        {
+            const string source = @"namespace Test;
+[if]
+private void Function() {}";
+            var syntaxTree = ParseSource(source, out var diagnostics);
+
+            Assert.That(syntaxTree, Is.Null);
+            diagnostics.AssertDiagnosticAt(DiagnosticCode.ExpectedAttributeName, 2, 1).WithActual("if");
+        }
+
+        [Test]
+        public void Must_have_closing_bracket()
+        {
+            const string source = @"namespace Test;
+[Attribute
+private void Function() {}";
+            var syntaxTree = ParseSource(source, out var diagnostics);
+
+            Assert.That(syntaxTree, Is.Null);
+            diagnostics.AssertDiagnosticAt(DiagnosticCode.ExpectedClosingBracket, 3, 0).WithActual("private");
+        }
+
+        [Test]
+        public void Cannot_apply_attribute_to_namespace()
+        {
+            const string source = "[AttributeType] namespace Test;";
+            var syntaxTree = ParseSource(source, out var diagnostics);
+
+            Assert.That(syntaxTree, Is.Null);
+            diagnostics.AssertDiagnosticAt(DiagnosticCode.AttributesOnlyApplicableToFunctions, 1, 16);
+        }
+    }
+}

--- a/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/DeclarationTests.cs
+++ b/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/DeclarationTests.cs
@@ -13,7 +13,8 @@ namespace Cle.SemanticAnalysis.UnitTests.MethodCompilerTests
         public void CompileDeclaration_parameterless_bool_method_succeeds()
         {
             var position = new TextPosition(13, 3, 4);
-            var syntax = new FunctionSyntax("MethodName", "bool", Visibility.Public,
+            var syntax = new FunctionSyntax("MethodName", "bool",
+                Visibility.Public, ImmutableList<AttributeSyntax>.Empty,
                 new BlockSyntax(ImmutableList<StatementSyntax>.Empty, default), position);
             var diagnostics = new TestingDiagnosticSink();
             var declarationProvider = new TestingSingleFileDeclarationProvider();
@@ -33,7 +34,8 @@ namespace Cle.SemanticAnalysis.UnitTests.MethodCompilerTests
         public void CompileDeclaration_parameterless_int32_method_succeeds()
         {
             var position = new TextPosition(280, 14, 8);
-            var syntax = new FunctionSyntax("MethodName", "int32", Visibility.Private,
+            var syntax = new FunctionSyntax("MethodName", "int32",
+                Visibility.Private, ImmutableList<AttributeSyntax>.Empty,
                 new BlockSyntax(ImmutableList<StatementSyntax>.Empty, default), position);
             var diagnostics = new TestingDiagnosticSink();
             var declarationProvider = new TestingSingleFileDeclarationProvider();
@@ -52,7 +54,8 @@ namespace Cle.SemanticAnalysis.UnitTests.MethodCompilerTests
         [Test]
         public void CompileDeclaration_parameterless_method_with_unknown_type_fails()
         {
-            var syntax = new FunctionSyntax("MethodName", "UltimateBool", Visibility.Public,
+            var syntax = new FunctionSyntax("MethodName", "UltimateBool", 
+                Visibility.Public, ImmutableList<AttributeSyntax>.Empty,
                 new BlockSyntax(ImmutableList<StatementSyntax>.Empty, default), new TextPosition(3, 1, 3));
             var diagnostics = new TestingDiagnosticSink();
             var declarationProvider = new TestingSingleFileDeclarationProvider();


### PR DESCRIPTION
Fixes #3. Implemented parsing of parameterless attributes, added handling of `[EntryPoint]` to declaration compilation and added a check for single entry point.