### PR TITLE
Implement simple while loops

### DIFF
--- a/src/Cle.Parser/Lexer.cs
+++ b/src/Cle.Parser/Lexer.cs
@@ -310,7 +310,8 @@ namespace Cle.Parser
                 (Encoding.UTF8.GetBytes("private"), TokenType.Private),
                 (Encoding.UTF8.GetBytes("public"), TokenType.Public),
                 (Encoding.UTF8.GetBytes("return"), TokenType.Return),
-                (Encoding.UTF8.GetBytes("true"), TokenType.True)
+                (Encoding.UTF8.GetBytes("true"), TokenType.True),
+                (Encoding.UTF8.GetBytes("while"), TokenType.While),
             };
         }
     }

--- a/src/Cle.Parser/SyntaxParser.cs
+++ b/src/Cle.Parser/SyntaxParser.cs
@@ -181,9 +181,7 @@ namespace Cle.Parser
             attribute = null;
 
             // Eat the '['
-            Debug.Assert(_lexer.PeekTokenType() == TokenType.OpenBracket);
-            var startPosition = _lexer.Position;
-            _lexer.GetToken();
+            var startPosition = EatAndAssertToken(TokenType.OpenBracket);
 
             // Read the attribute name
             if (_lexer.PeekTokenType() != TokenType.Identifier)
@@ -210,8 +208,7 @@ namespace Cle.Parser
             namespaceName = string.Empty;
 
             // Eat the 'namespace' token
-            Debug.Assert(_lexer.PeekTokenType() == TokenType.Namespace);
-            _lexer.GetToken();
+            EatAndAssertToken(TokenType.Namespace);
 
             // Read and validate the namespace name
             if (_lexer.PeekTokenType() != TokenType.Identifier)
@@ -241,9 +238,7 @@ namespace Cle.Parser
             block = null;
 
             // Eat the opening brace
-            var startPosition = _lexer.Position;
-            Debug.Assert(_lexer.PeekTokenType() == TokenType.OpenBrace);
-            _lexer.GetToken();
+            var startPosition = EatAndAssertToken(TokenType.OpenBrace);
 
             // Parse statements until a closing brace is found
             var statementList = ImmutableList<StatementSyntax>.Empty.ToBuilder();
@@ -328,9 +323,7 @@ namespace Cle.Parser
             ifStatement = null;
 
             // Eat the 'if' keyword
-            var startPosition = _lexer.Position;
-            Debug.Assert(_lexer.PeekTokenType() == TokenType.If);
-            _lexer.GetToken();
+            var startPosition = EatAndAssertToken(TokenType.If);
 
             // Read the condition
             if (!TryParseCondition(out var condition))
@@ -397,9 +390,7 @@ namespace Cle.Parser
             returnStatement = null;
 
             // Eat the 'return' keyword
-            var startPosition = _lexer.Position;
-            Debug.Assert(_lexer.PeekTokenType() == TokenType.Return);
-            _lexer.GetToken();
+            var startPosition = EatAndAssertToken(TokenType.Return);
 
             // There are two kinds of returns: void return and value return.
             // In case of the former, the keyword is immediately followed by a semicolon.
@@ -428,9 +419,7 @@ namespace Cle.Parser
             whileStatement = null;
 
             // Eat the 'while' keyword
-            var startPosition = _lexer.Position;
-            Debug.Assert(_lexer.PeekTokenType() == TokenType.While);
-            _lexer.GetToken();
+            var startPosition = EatAndAssertToken(TokenType.While);
 
             // Parse the condition
             if (!TryParseCondition(out var condition))
@@ -777,6 +766,22 @@ namespace Cle.Parser
                 default:
                     return Visibility.Unknown;
             }
+        }
+
+        /// <summary>
+        /// Eats a token and throws if the token type does not match.
+        /// Returns the token position.
+        /// </summary>
+        private TextPosition EatAndAssertToken(TokenType expectedTokenType)
+        {
+            if (_lexer.PeekTokenType() != expectedTokenType)
+            {
+                throw new InvalidOperationException(
+                    $"The method requires {expectedTokenType} but read {_lexer.PeekTokenType()}.");
+            }
+            _lexer.GetToken();
+
+            return _lexer.LastPosition;
         }
 
         /// <summary>

--- a/src/Cle.Parser/SyntaxTree/WhileStatementSyntax.cs
+++ b/src/Cle.Parser/SyntaxTree/WhileStatementSyntax.cs
@@ -1,0 +1,33 @@
+﻿using Cle.Common;
+using JetBrains.Annotations;
+
+namespace Cle.Parser.SyntaxTree
+{
+    /// <summary>
+    /// Syntax tree node for an 'while' loop statement.
+    /// </summary>
+    public sealed class WhileStatementSyntax : StatementSyntax
+    {
+        /// <summary>
+        /// Gets the condition expression.
+        /// </summary>
+        [NotNull]
+        public ExpressionSyntax ConditionSyntax { get; }
+
+        /// <summary>
+        /// Gets the block that will be executed while the condition is true.
+        /// </summary>
+        [NotNull]
+        public BlockSyntax BodySyntax { get; }
+
+        public WhileStatementSyntax(
+            [NotNull] ExpressionSyntax condition,
+            [NotNull] BlockSyntax body,
+            TextPosition position)
+            : base(position)
+        {
+            ConditionSyntax = condition;
+            BodySyntax = body;
+        }
+    }
+}

--- a/src/Cle.Parser/TokenType.cs
+++ b/src/Cle.Parser/TokenType.cs
@@ -23,6 +23,7 @@
         Public,
         Return,
         True,
+        While,
 
         // Symbols
         Plus,

--- a/test/Cle.Parser.UnitTests/SyntaxParserTests/WhileTests.cs
+++ b/test/Cle.Parser.UnitTests/SyntaxParserTests/WhileTests.cs
@@ -1,0 +1,85 @@
+using Cle.Common;
+using Cle.Parser.SyntaxTree;
+using NUnit.Framework;
+
+namespace Cle.Parser.UnitTests.SyntaxParserTests
+{
+    public class WhileTests : SyntaxParserTestBase
+    {
+        [Test]
+        public void Simple_loop_with_constant_condition()
+        {
+            const string source = @"namespace Test;
+private bool Function()
+{
+    while (true) {
+        return true;
+    }
+}";
+            var block = ParseBlockForSingleFunction(source);
+
+            Assert.That(block.Statements, Has.Exactly(1).Items);
+            Assert.That(block.Statements[0], Is.InstanceOf<WhileStatementSyntax>());
+
+            var loop = (WhileStatementSyntax)block.Statements[0];
+            Assert.That(loop.ConditionSyntax, Is.InstanceOf<BooleanLiteralSyntax>());
+            Assert.That(loop.BodySyntax.Statements, Has.Exactly(1).Items);
+        }
+
+        [Test]
+        public void Condition_must_be_valid()
+        {
+            const string source = @"namespace Test;
+private void Error()
+{
+    while (if) { }
+}";
+            var syntaxTree = ParseSource(source, out var diagnostics);
+
+            Assert.That(syntaxTree, Is.Null);
+            diagnostics.AssertDiagnosticAt(DiagnosticCode.ExpectedExpression, 4, 11).WithActual("if");
+        }
+
+        [Test]
+        public void Condition_must_be_within_parens()
+        {
+            const string source = @"namespace Test;
+private void Error()
+{
+    while true { }
+}";
+            var syntaxTree = ParseSource(source, out var diagnostics);
+
+            Assert.That(syntaxTree, Is.Null);
+            diagnostics.AssertDiagnosticAt(DiagnosticCode.ExpectedCondition, 4, 10).WithActual("true");
+        }
+
+        [Test]
+        public void Body_must_be_valid()
+        {
+            const string source = @"namespace Test;
+private void Error()
+{
+    while (true) { 42 }
+}";
+            var syntaxTree = ParseSource(source, out var diagnostics);
+
+            Assert.That(syntaxTree, Is.Null);
+            diagnostics.AssertDiagnosticAt(DiagnosticCode.ExpectedStatement, 4, 19).WithActual("42");
+        }
+
+        [Test]
+        public void Must_have_body()
+        {
+            const string source = @"namespace Test;
+private void Error()
+{
+    while (true)
+}";
+            var syntaxTree = ParseSource(source, out var diagnostics);
+
+            Assert.That(syntaxTree, Is.Null);
+            diagnostics.AssertDiagnosticAt(DiagnosticCode.ExpectedBlock, 5, 0).WithActual("}");
+        }
+    }
+}

--- a/test/Cle.Parser.UnitTests/SyntaxParserTests/WhileTests.cs
+++ b/test/Cle.Parser.UnitTests/SyntaxParserTests/WhileTests.cs
@@ -74,12 +74,12 @@ private void Error()
             const string source = @"namespace Test;
 private void Error()
 {
-    while (true)
+    while (true) return true;
 }";
             var syntaxTree = ParseSource(source, out var diagnostics);
 
             Assert.That(syntaxTree, Is.Null);
-            diagnostics.AssertDiagnosticAt(DiagnosticCode.ExpectedBlock, 5, 0).WithActual("}");
+            diagnostics.AssertDiagnosticAt(DiagnosticCode.ExpectedBlock, 4, 17).WithActual("return");
         }
     }
 }

--- a/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/ReturnGuaranteeTests.cs
+++ b/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/ReturnGuaranteeTests.cs
@@ -6,7 +6,7 @@ namespace Cle.SemanticAnalysis.UnitTests.MethodCompilerTests
     public class ReturnGuaranteeTests : MethodCompilerTestBase
     {
         [Test]
-        public void Int32_method_without_return_fails()
+        public void Method_without_return_fails()
         {
             const string source = @"namespace Test;
 public int32 Fail() {
@@ -19,7 +19,7 @@ public int32 Fail() {
         }
 
         [Test]
-        public void Int32_method_without_return_in_one_branch_fails()
+        public void Method_without_return_in_one_branch_fails()
         {
             const string source = @"namespace Test;
 public int32 Fail() {
@@ -34,7 +34,7 @@ public int32 Fail() {
         }
 
         [Test]
-        public void Int32_method_without_return_in_else_if_branch_fails()
+        public void Method_without_return_in_else_if_branch_fails()
         {
             const string source = @"namespace Test;
 public int32 Fail() {
@@ -52,7 +52,7 @@ public int32 Fail() {
         }
 
         [Test]
-        public void Int32_method_with_unreachable_block_causes_warning()
+        public void Method_with_unreachable_block_causes_warning()
         {
             const string source = @"namespace Test;
 public int32 Warn() {
@@ -83,7 +83,7 @@ public int32 Warn() {
         }
 
         [Test]
-        public void Int32_method_with_return_in_nested_block_causes_two_warnings()
+        public void Method_with_return_in_nested_block_causes_two_warnings()
         {
             const string source = @"namespace Test;
 public int32 Warn() {
@@ -102,7 +102,7 @@ public int32 Warn() {
         }
 
         [Test]
-        public void Int32_method_with_return_in_two_if_branches_causes_warning()
+        public void Method_with_return_in_two_if_branches_causes_warning()
         {
             const string source = @"namespace Test;
 public int32 Warn() {
@@ -119,7 +119,7 @@ public int32 Warn() {
         }
 
         [Test]
-        public void Int32_method_with_return_in_three_if_branches_causes_warning()
+        public void Method_with_return_in_three_if_branches_causes_warning()
         {
             const string source = @"namespace Test;
 public int32 Warn() {
@@ -137,6 +137,34 @@ public int32 Warn() {
             diagnostics.AssertDiagnosticAt(DiagnosticCode.UnreachableCode, 8, 4);
         }
 
-        // TODO: Warning for constant condition in if
+        [Test]
+        public void Method_with_return_only_in_while_fails()
+        {
+            const string source = @"namespace Test;
+public int32 Fail() {
+    bool a = true;
+    while (a) { return 1; }
+}";
+            var compiledMethod = TryCompileSingleMethod(source, out var diagnostics);
+
+            Assert.That(compiledMethod, Is.Null);
+            Assert.That(diagnostics.Diagnostics, Has.Exactly(1).Items);
+            diagnostics.AssertDiagnosticAt(DiagnosticCode.ReturnNotGuaranteed, 2, 0).WithActual("Fail");
+        }
+
+        [Test]
+        public void Method_with_return_in_while_does_not_cause_warning()
+        {
+            const string source = @"namespace Test;
+public int32 Warn() {
+    bool a = true;
+    while (a) { return 1; }
+    return 4;
+}";
+            var compiledMethod = TryCompileSingleMethod(source, out var diagnostics);
+
+            Assert.That(compiledMethod, Is.Not.Null);
+            Assert.That(diagnostics.Diagnostics, Is.Empty);
+        }
     }
 }

--- a/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/WhileTests.cs
+++ b/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/WhileTests.cs
@@ -1,0 +1,106 @@
+using Cle.Common;
+using NUnit.Framework;
+
+namespace Cle.SemanticAnalysis.UnitTests.MethodCompilerTests
+{
+    public class WhileTests : MethodCompilerTestBase
+    {
+        [Test]
+        public void Empty_loop_with_constant_condition()
+        {
+            const string source = @"namespace Test;
+public bool Stupid() {
+    while (true) {
+    }
+    return false;
+}";
+            var compiledMethod = TryCompileSingleMethod(source, out var diagnostics);
+
+            Assert.That(compiledMethod, Is.Not.Null);
+            Assert.That(diagnostics.Diagnostics, Is.Empty);
+            
+            AssertDisassembly(compiledMethod, @"
+; #0   bool = true
+; #1   bool = false
+BB_0:
+
+BB_1:
+    BranchIf #0 ==> BB_2
+    ==> BB_3
+
+BB_2:
+    ==> BB_1
+
+BB_3:
+    Return #1");
+        }
+
+        [Test]
+        public void More_complex_loop_with_constant_condition()
+        {
+            const string source = @"namespace Test;
+public bool Stupid() {
+    bool a = false;
+    bool b = a;
+    while (false) {
+        if (a) { b = a; }
+    }
+    return b;
+}";
+            var compiledMethod = TryCompileSingleMethod(source, out var diagnostics);
+
+            Assert.That(compiledMethod, Is.Not.Null);
+            Assert.That(diagnostics.Diagnostics, Is.Empty);
+            
+            AssertDisassembly(compiledMethod, @"
+; #0   bool = false
+; #1   bool = void
+; #2   bool = false
+BB_0:
+    CopyValue #0 -> #1
+
+BB_1:
+    BranchIf #2 ==> BB_2
+    ==> BB_5
+
+BB_2:
+    BranchIf #0 ==> BB_3
+    ==> BB_4
+
+BB_3:
+    CopyValue #0 -> #1
+
+BB_4:
+    ==> BB_1
+
+BB_5:
+    Return #1");
+        }
+
+        [Test]
+        public void Condition_must_be_bool()
+        {
+            const string source = @"namespace Test;
+public bool TypeMismatchInWhile() {
+    while (42) {}
+}";
+            var compiledMethod = TryCompileSingleMethod(source, out var diagnostics);
+
+            Assert.That(compiledMethod, Is.Null);
+            diagnostics.AssertDiagnosticAt(DiagnosticCode.TypeMismatch, 3, 11).WithExpected("bool").WithActual("int32");
+        }
+
+        [Test]
+        public void Body_must_be_valid()
+        {
+            const string source = @"namespace Test;
+public bool TypeMismatchInWhile() {
+    while (true) { bool a = 42; }
+}";
+            var compiledMethod = TryCompileSingleMethod(source, out var diagnostics);
+
+            Assert.That(compiledMethod, Is.Null);
+            diagnostics.AssertDiagnosticAt(DiagnosticCode.TypeMismatch, 3, 28).WithExpected("bool").WithActual("int32");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #7. Implemented simple `while (...) { ... }` loops without `continue` and `break` and left the remaining work for the future (not necessary for now). Might not be tested well enough.