### PR TITLE
Clean up the frontend and implement debug dumping

### DIFF
--- a/cle.sln
+++ b/cle.sln
@@ -27,6 +27,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cle.SemanticAnalysis.UnitTe
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cle.UnitTests.Common", "test\Cle.UnitTests.Common\Cle.UnitTests.Common.csproj", "{50038DC7-5193-47CD-A789-E289BE181CC0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cle.Frontend.UnitTests", "test\Cle.Frontend.UnitTests\Cle.Frontend.UnitTests.csproj", "{9C8387AA-EB58-4819-AAF5-16B6A6CFD348}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -72,6 +74,10 @@ Global
 		{50038DC7-5193-47CD-A789-E289BE181CC0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{50038DC7-5193-47CD-A789-E289BE181CC0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{50038DC7-5193-47CD-A789-E289BE181CC0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9C8387AA-EB58-4819-AAF5-16B6A6CFD348}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9C8387AA-EB58-4819-AAF5-16B6A6CFD348}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9C8387AA-EB58-4819-AAF5-16B6A6CFD348}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9C8387AA-EB58-4819-AAF5-16B6A6CFD348}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -87,6 +93,7 @@ Global
 		{2132E910-AA45-44D9-95FE-F4D3A0C1D0EE} = {A14775F6-0FFF-449E-8160-D31C668A441A}
 		{DE0352C7-509B-4BAE-B9E2-5EA4343E788B} = {3A372906-46C7-4D1B-A71B-48888E2F1A8F}
 		{50038DC7-5193-47CD-A789-E289BE181CC0} = {3A372906-46C7-4D1B-A71B-48888E2F1A8F}
+		{9C8387AA-EB58-4819-AAF5-16B6A6CFD348} = {3A372906-46C7-4D1B-A71B-48888E2F1A8F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5F2D74AA-DFCB-4E95-8578-F81259CC155E}

--- a/src/Cle.Compiler/CompilationOptions.cs
+++ b/src/Cle.Compiler/CompilationOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace Cle.Compiler
+﻿using JetBrains.Annotations;
+
+namespace Cle.Compiler
 {
     /// <summary>
     /// Additional options for the compiler.
@@ -6,14 +8,27 @@
     public class CompilationOptions
     {
         /// <summary>
-        /// If true, the compiler should dump debug logging.
+        /// If true, the compiler should dump debug logging for methods matching <see cref="DebugPattern"/>.
         /// Some of this debug logging may be only enabled in Debug builds of the compiler.
         /// </summary>
-        public bool DebugOutput { get; }
+        public bool DebugOutput => DebugPattern != null;
 
-        public CompilationOptions(bool debugOutput = false)
+        /// <summary>
+        /// Gets a regex pattern the will be used for matching method names to dump debug logging for.
+        /// </summary>
+        [CanBeNull]
+        public string DebugPattern { get; }
+
+        /// <summary>
+        /// Gets the name of the main module.
+        /// </summary>
+        [NotNull]
+        public string MainModule { get; }
+
+        public CompilationOptions([NotNull] string mainModule, string debugPattern = null)
         {
-            DebugOutput = debugOutput;
+            MainModule = mainModule;
+            DebugPattern = debugPattern;
         }
     }
 }

--- a/src/Cle.Compiler/CompilerDriver.cs
+++ b/src/Cle.Compiler/CompilerDriver.cs
@@ -18,14 +18,10 @@ namespace Cle.Compiler
         /// Compiles the specified module and its dependencies.
         /// Returns compilation diagnostics and statistics.
         /// </summary>
-        /// <param name="mainModule">
-        /// The main module name. This module will be located and its dependencies will be added to the compilation.
-        /// </param>
         /// <param name="options">Additional options, such as optimization and logging levels.</param>
         /// <param name="sourceFileProvider">Interface for source file access.</param>
         [NotNull]
         public static CompilationResult Compile(
-            [NotNull] string mainModule,
             [NotNull] CompilationOptions options,
             [NotNull] ISourceFileProvider sourceFileProvider)
         {
@@ -34,6 +30,7 @@ namespace Cle.Compiler
             var compilation = new Compilation();
 
             // TODO: Build the dependency graph and decide the build order
+            var mainModule = options.MainModule;
 
             // Parse each module
             // TODO: Make this run in parallel

--- a/src/Cle.Compiler/DebugLogger.cs
+++ b/src/Cle.Compiler/DebugLogger.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using Cle.SemanticAnalysis;
+using Cle.SemanticAnalysis.IR;
+using JetBrains.Annotations;
+
+namespace Cle.Compiler
+{
+    /// <summary>
+    /// Implements compiler debug logging such as dumping the IR of user-specified methods in various phases.
+    /// </summary>
+    internal class DebugLogger
+    {
+        [CanBeNull] private readonly TextWriter _writer;
+        [CanBeNull] private readonly string _pattern;
+
+        /// <summary>
+        /// Creates a logger.
+        /// If <paramref name="writer"/> is null, instance methods are no-ops.
+        /// </summary>
+        /// <param name="writer">
+        /// An optional writer for the debug logging. If null, no output is produced.
+        /// </param>
+        /// <param name="methodPattern">
+        /// A string that is searched for in method names.
+        /// A null pattern matches no method and "*" or empty matches all methods.
+        /// </param>
+        public DebugLogger([CanBeNull] TextWriter writer, [CanBeNull] string methodPattern)
+        {
+            _writer = writer;
+
+            if (methodPattern is null)
+            {
+                WriteLine("No method pattern specified: no methods will be dumped.");
+            }
+            // Empty string is contained in every string
+            _pattern = methodPattern == "*" ? "" : methodPattern;
+        }
+
+        /// <summary>
+        /// Returns true iff the method name contains the pattern string and logging is enabled. 
+        /// </summary>
+        /// <param name="methodName">The full name of the method to match.</param>
+        public bool ShouldLog([NotNull] string methodName)
+        {
+            return _writer != null && _pattern != null &&
+                methodName.IndexOf(_pattern, StringComparison.InvariantCultureIgnoreCase) != -1;
+        }
+
+        /// <summary>
+        /// If <paramref name="methodName"/> matches the method name, the method will be disassembled
+        /// to the output writer.
+        /// </summary>
+        /// <param name="method">The method IR.</param>
+        public void DumpMethod([NotNull] CompiledMethod method)
+        {
+            if (!ShouldLog(method.FullName))
+                return;
+
+            // Write the full name as a comment
+            _writer.Write("; ");
+            _writer.WriteLine(method.FullName);
+
+            // Disassemble the method
+            if (method.Body is null)
+            {
+                _writer.WriteLine("; (Method has no body)");
+                _writer.WriteLine();
+            }
+            else
+            {
+                var builder = new StringBuilder();
+                MethodDisassembler.Disassemble(method, builder);
+
+                _writer.Write(builder);
+            }
+            _writer.WriteLine();
+        }
+
+        /// <summary>
+        /// Writes a header surrounded by padding and a header sign.
+        /// </summary>
+        /// <param name="header">The header text.</param>
+        public void WriteHeader([NotNull] string header)
+        {
+            if (_writer != null)
+            {
+                _writer.WriteLine();
+                _writer.WriteLine();
+                _writer.Write("## ");
+                _writer.WriteLine(header);
+                _writer.WriteLine();
+            }
+        }
+
+        /// <summary>
+        /// Writes the specified text followed by a newline.
+        /// </summary>
+        public void WriteLine([NotNull] string text)
+        {
+            if (_writer != null)
+            {
+                _writer.WriteLine(text);
+            }
+        }
+    }
+}

--- a/src/Cle.Compiler/IOutputFileProvider.cs
+++ b/src/Cle.Compiler/IOutputFileProvider.cs
@@ -1,0 +1,19 @@
+﻿using System.IO;
+using JetBrains.Annotations;
+
+namespace Cle.Compiler
+{
+    /// <summary>
+    /// Provides methods for creating output file streams.
+    /// The lifetime is handled by the creator.
+    /// </summary>
+    public interface IOutputFileProvider
+    {
+        /// <summary>
+        /// Gets a debug log writer.
+        /// May return null if the file can not be created.
+        /// </summary>
+        [CanBeNull]
+        TextWriter GetDebugFileWriter();
+    }
+}

--- a/src/Cle.Frontend/AssemblyInfo.cs
+++ b/src/Cle.Frontend/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Cle.Frontend.UnitTests")]
+
+[assembly: AssemblyCopyright("(c) 2018, 2019 Petri Laarne")]

--- a/src/Cle.Frontend/Cle.Frontend.csproj
+++ b/src/Cle.Frontend/Cle.Frontend.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.3.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2018.2.1" />
   </ItemGroup>
   

--- a/src/Cle.Frontend/CommandLineOptions.cs
+++ b/src/Cle.Frontend/CommandLineOptions.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using CommandLine;
+using JetBrains.Annotations;
+
+namespace Cle.Frontend
+{
+    /// <summary>
+    /// Possible command line arguments.
+    /// </summary>
+    internal class CommandLineOptions
+    {
+        [CanBeNull]
+        [Option("dump", HelpText = "If specified, debug information for all methods " + 
+            "matching the regex parameter will be dumped to cle-dump.txt.")]
+        public string DumpRegex { get; set; }
+
+        [CanBeNull, ItemNotNull]
+        [Value(0, Required = false, Max = 1,
+            HelpText = "Main module path relative to current directory.", MetaName = "module")]
+        public IEnumerable<string> MainModule { get; set; }
+    }
+}

--- a/src/Cle.Frontend/CommandLineOptions.cs
+++ b/src/Cle.Frontend/CommandLineOptions.cs
@@ -10,8 +10,9 @@ namespace Cle.Frontend
     internal class CommandLineOptions
     {
         [CanBeNull]
-        [Option("dump", HelpText = "If specified, debug information for all methods " + 
-            "matching the regex parameter will be dumped to cle-dump.txt.")]
+        [Option("dump", HelpText = "If specified, compiler debug information for all methods " + 
+            "where the name contains the parameter string will be logged to cle-dump.txt. " +
+            "Specify * to dump all methods. More complex wildcard syntax is not supported.")]
         public string DumpRegex { get; set; }
 
         [CanBeNull, ItemNotNull]

--- a/src/Cle.Frontend/CommandLineOptions.cs
+++ b/src/Cle.Frontend/CommandLineOptions.cs
@@ -15,7 +15,7 @@ namespace Cle.Frontend
         public string DumpRegex { get; set; }
 
         [CanBeNull, ItemNotNull]
-        [Value(0, Required = false, Max = 1,
+        [Value(0, Required = false,
             HelpText = "Main module path relative to current directory.", MetaName = "module")]
         public IEnumerable<string> MainModule { get; set; }
     }

--- a/src/Cle.Frontend/CommandLineParser.cs
+++ b/src/Cle.Frontend/CommandLineParser.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Cle.Compiler;
+using CommandLine;
+using JetBrains.Annotations;
+
+namespace Cle.Frontend
+{
+    /// <summary>
+    /// Provides static methods for handling the command line interface.
+    /// </summary>
+    internal static class CommandLineParser
+    {
+        /// <summary>
+        /// Tries to parse the command line arguments.
+        /// Returns false if parsing fails or no compilation is to be done.
+        /// </summary>
+        /// <param name="args">The command line arguments passed to the executable.</param>
+        /// <param name="output">A writer for any output such as help.</param>
+        /// <param name="options">The parsed compilation options, if successful.</param>
+        public static bool TryParseArguments(
+            [NotNull, ItemNotNull] IEnumerable<string> args,
+            [NotNull] TextWriter output,
+            [CanBeNull] out CompilationOptions options)
+        {
+            var parser = new CommandLine.Parser(config =>
+            {
+                config.HelpWriter = output;
+            });
+            var result = parser.ParseArguments<CommandLineOptions>(args);
+
+            if (result is Parsed<CommandLineOptions> parsed)
+            {
+                // Convert the options into compilation options
+                options = new CompilationOptions(
+                    parsed.Value.MainModule.FirstOrDefault() ?? ".",
+                    debugPattern: parsed.Value.DumpRegex);
+
+                return true;
+            }
+            else
+            {
+                options = null;
+                return false;
+            }
+        }
+    }
+}

--- a/src/Cle.Frontend/CommandLineParser.cs
+++ b/src/Cle.Frontend/CommandLineParser.cs
@@ -34,6 +34,19 @@ namespace Cle.Frontend
 
             if (result is Parsed<CommandLineOptions> parsed)
             {
+                // Handle the case where multiple main modules are specified by ourselves.
+                // We could also set an Value attribute property Max=1, but the error message would be:
+                //   "A sequence value not bound to option name is defined with few items than required."
+                // So yeah, maybe it is better to handle that by ourselves.
+                if (parsed.Value.MainModule.Count() > 1)
+                {
+                    output.WriteLine("ERROR(S):");
+                    output.WriteLine("More than one main module specified.");
+
+                    options = null;
+                    return false;
+                }
+
                 // Convert the options into compilation options
                 options = new CompilationOptions(
                     parsed.Value.MainModule.FirstOrDefault() ?? ".",

--- a/src/Cle.Frontend/CommandLineParser.cs
+++ b/src/Cle.Frontend/CommandLineParser.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using Cle.Compiler;
 using CommandLine;
 using JetBrains.Annotations;
@@ -38,7 +35,8 @@ namespace Cle.Frontend
                 // We could also set an Value attribute property Max=1, but the error message would be:
                 //   "A sequence value not bound to option name is defined with few items than required."
                 // So yeah, maybe it is better to handle that by ourselves.
-                if (parsed.Value.MainModule.Count() > 1)
+                var mainModules = new List<string>(parsed.Value.MainModule);
+                if (mainModules.Count > 1)
                 {
                     output.WriteLine("ERROR(S):");
                     output.WriteLine("More than one main module specified.");
@@ -49,7 +47,7 @@ namespace Cle.Frontend
 
                 // Convert the options into compilation options
                 options = new CompilationOptions(
-                    parsed.Value.MainModule.FirstOrDefault() ?? ".",
+                    mainModules.Count == 0 ? "." : mainModules[0],
                     debugPattern: parsed.Value.DumpRegex);
 
                 return true;

--- a/src/Cle.Frontend/OutputFileProvider.cs
+++ b/src/Cle.Frontend/OutputFileProvider.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.IO;
+using Cle.Compiler;
+using JetBrains.Annotations;
+
+namespace Cle.Frontend
+{
+    internal class OutputFileProvider : IOutputFileProvider, IDisposable
+    {
+        [NotNull] private readonly string _baseDirectory;
+        [CanBeNull] private TextWriter _debugWriter;
+
+        public OutputFileProvider([NotNull] string baseDirectory)
+        {
+            _baseDirectory = baseDirectory;
+        }
+
+        public void Dispose()
+        {
+            _debugWriter?.Dispose();
+        }
+
+        public TextWriter GetDebugFileWriter()
+        {
+            if (_debugWriter is null)
+            {
+                try
+                {
+                    _debugWriter = File.CreateText(Path.Combine(_baseDirectory, "cle-dump.txt"));
+                }
+                catch (IOException)
+                {
+                    return null;
+                }
+            }
+
+            return _debugWriter;
+        }
+    }
+}

--- a/src/Cle.Frontend/Program.cs
+++ b/src/Cle.Frontend/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using Cle.Compiler;
 
@@ -8,11 +9,12 @@ namespace Cle.Frontend
     {
         public static int Main(string[] args)
         {
-            Console.WriteLine("Cle Compiler");
-            Console.WriteLine("WIP: This executable currently only parses the Cle files in current directory.");
-            Console.WriteLine();
-
-            // TODO: Read command line parameters
+            // Read command line parameters
+            if (!CommandLineParser.TryParseArguments(args, Console.Out, out var options))
+            {
+                return 0;
+            }
+            Debug.Assert(options != null);
 
             // TODO: Create a logger for diagnostics and output messages as they are produced
 
@@ -20,7 +22,7 @@ namespace Cle.Frontend
             var fileProvider = new SourceFileProvider(Directory.GetCurrentDirectory());
 
             // TODO: Initialize a compiler instance and call it
-            var result = CompilerDriver.Compile(".", new CompilationOptions(), fileProvider);
+            var result = CompilerDriver.Compile(options, fileProvider);
 
             // Write an output summary
             PrintDiagnostics(result);

--- a/src/Cle.Frontend/Program.cs
+++ b/src/Cle.Frontend/Program.cs
@@ -12,16 +12,16 @@ namespace Cle.Frontend
             // Read command line parameters
             if (!CommandLineParser.TryParseArguments(args, Console.Out, out var options))
             {
-                return 0;
+                return 1;
             }
             Debug.Assert(options != null);
 
             // TODO: Create a logger for diagnostics and output messages as they are produced
 
-            // TODO: Create a file interface
+            // Create a file interface
             var fileProvider = new SourceFileProvider(Directory.GetCurrentDirectory());
 
-            // TODO: Initialize a compiler instance and call it
+            // Initialize a compiler instance and call it
             var result = CompilerDriver.Compile(options, fileProvider);
 
             // Write an output summary
@@ -45,8 +45,8 @@ namespace Cle.Frontend
             }
             Console.WriteLine($"Succeeded modules: {result.SucceededCount}, Failed modules: {result.FailedCount}");
 
-            // TODO: Return an according return value
-            return 0;
+            // Return an according return value
+            return result.FailedCount;
         }
 
         private static void PrintDiagnostics(CompilationResult result)

--- a/src/Cle.Frontend/Program.cs
+++ b/src/Cle.Frontend/Program.cs
@@ -18,15 +18,36 @@ namespace Cle.Frontend
 
             // TODO: Create a logger for diagnostics and output messages as they are produced
 
-            // Create a file interface
-            var fileProvider = new SourceFileProvider(Directory.GetCurrentDirectory());
+            // Create file interfaces
+            var sourceProvider = new SourceFileProvider(Directory.GetCurrentDirectory());
+            using (var outputProvider = new OutputFileProvider(Directory.GetCurrentDirectory()))
+            {
 
-            // Initialize a compiler instance and call it
-            var result = CompilerDriver.Compile(options, fileProvider);
+                // Initialize a compiler instance and call it
+                var result = CompilerDriver.Compile(options, sourceProvider, outputProvider);
 
-            // Write an output summary
-            PrintDiagnostics(result);
-            
+                // Write an output summary
+                PrintDiagnostics(result);
+                PrintSummary(result);
+
+                // Return an according return value
+                return result.FailedCount;
+            }
+        }
+
+        private static void PrintDiagnostics(CompilationResult result)
+        {
+            foreach (var diagnostic in result.Diagnostics)
+            {
+                // TODO: Display paths relative to module root, including subdirectories
+                Console.WriteLine($"{Path.GetFileName(diagnostic.Filename)} " +
+                                  $"({diagnostic.Position.Line},{diagnostic.Position.ByteInLine}): " +
+                                  DiagnosticMessages.GetMessage(diagnostic));
+            }
+        }
+
+        private static void PrintSummary(CompilationResult result)
+        {
             if (result.Diagnostics.Count > 0)
             {
                 // Separate the diagnostics list from the summary
@@ -43,21 +64,8 @@ namespace Cle.Frontend
                 Console.WriteLine("Build failed.");
                 Console.ResetColor();
             }
+
             Console.WriteLine($"Succeeded modules: {result.SucceededCount}, Failed modules: {result.FailedCount}");
-
-            // Return an according return value
-            return result.FailedCount;
-        }
-
-        private static void PrintDiagnostics(CompilationResult result)
-        {
-            foreach (var diagnostic in result.Diagnostics)
-            {
-                // TODO: Display paths relative to module root, including subdirectories
-                Console.WriteLine($"{Path.GetFileName(diagnostic.Filename)} " +
-                                  $"({diagnostic.Position.Line},{diagnostic.Position.ByteInLine}): " +
-                                  DiagnosticMessages.GetMessage(diagnostic));
-            }
         }
     }
 }

--- a/src/Cle.Frontend/SourceFileProvider.cs
+++ b/src/Cle.Frontend/SourceFileProvider.cs
@@ -17,13 +17,20 @@ namespace Cle.Frontend
 
         public bool TryGetFilenamesForModule(string moduleName, out IEnumerable<string> filenames)
         {
-            // TODO: Support for multiple modules
-            if (moduleName != ".")
-                throw new NotImplementedException("Support for modules");
-            
-            // TODO: Evaluate which exceptions can be handled (access denied, etc.)
-            filenames = Directory.EnumerateFiles(_mainDirectory, "*.cle", SearchOption.AllDirectories);
-            return true;
+            // Use absolute paths everywhere
+            // TODO: Support for module search paths
+            try
+            {
+                filenames = Directory.EnumerateFiles(Path.GetFullPath(Path.Combine(_mainDirectory, moduleName)),
+                    "*.cle", SearchOption.TopDirectoryOnly);
+                return true;
+            }
+            catch (IOException)
+            {
+                // TODO: Is there some kind of IO exception that should not be handled?
+                filenames = null;
+                return false;
+            }
         }
 
         public bool TryGetSourceFile(string filename, out Memory<byte> fileBytes)
@@ -35,7 +42,7 @@ namespace Cle.Frontend
             }
             catch (IOException)
             {
-                // TODO: Is there some kind of exception that cannot be handled?
+                // TODO: Is there some kind of IO exception that should not be handled?
                 // TODO: Should there be a way to message the type of error?
                 fileBytes = Memory<byte>.Empty;
                 return false;

--- a/src/Cle.SemanticAnalysis/IR/CompiledMethod.cs
+++ b/src/Cle.SemanticAnalysis/IR/CompiledMethod.cs
@@ -11,6 +11,12 @@ namespace Cle.SemanticAnalysis.IR
     public class CompiledMethod
     {
         /// <summary>
+        /// Gets the full name of this method.
+        /// This can be used for debugging and emitting symbols.
+        /// </summary>
+        public string FullName { get; }
+
+        /// <summary>
         /// Gets or sets the basic block graph for this method.
         /// </summary>
         public BasicBlockGraph Body { get; set; }
@@ -22,6 +28,11 @@ namespace Cle.SemanticAnalysis.IR
         public IReadOnlyList<LocalValue> Values => _values;
 
         private readonly List<LocalValue> _values = new List<LocalValue>();
+
+        public CompiledMethod([NotNull] string fullName)
+        {
+            FullName = fullName;
+        }
 
         /// <summary>
         /// Creates a new local value with the specified type and initial value, and returns its value index.

--- a/src/Cle.SemanticAnalysis/MethodCompiler.cs
+++ b/src/Cle.SemanticAnalysis/MethodCompiler.cs
@@ -128,8 +128,8 @@ namespace Cle.SemanticAnalysis
         {
             Debug.Assert(_syntaxTree != null);
             Debug.Assert(_sourceFilename != null);
-            
-            _methodInProgress = new CompiledMethod();
+
+            _methodInProgress = new CompiledMethod(_definingNamespace + "::" + _syntaxTree.Name);
 
             // TODO: Create locals for the parameters
 

--- a/test/Cle.Benchmarks/Compiler/CompilerDriverBenchmarks.cs
+++ b/test/Cle.Benchmarks/Compiler/CompilerDriverBenchmarks.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using BenchmarkDotNet.Attributes;
 using Cle.Compiler;
@@ -9,16 +10,19 @@ namespace Cle.Benchmarks.Compiler
     public class CompilerDriverBenchmarks
     {
         private readonly SingleFileProvider _almostSemanticallyValidSourceProvider;
+        private readonly NullOutputProvider _nullOutputProvider;
 
         public CompilerDriverBenchmarks()
         {
             _almostSemanticallyValidSourceProvider = new SingleFileProvider(AlmostSemanticallyValidSource);
+            _nullOutputProvider = new NullOutputProvider();
         }
 
         [Benchmark]
         public int CompileSingleFileWithSemanticError()
         {
-            var result = CompilerDriver.Compile(new CompilationOptions("."), _almostSemanticallyValidSourceProvider);
+            var result = CompilerDriver.Compile(new CompilationOptions("."),
+                _almostSemanticallyValidSourceProvider, _nullOutputProvider);
             return result.Diagnostics.Count;
         }
         
@@ -79,6 +83,14 @@ private bool TypeMismatch()
                     fileBytes = Memory<byte>.Empty;
                     return false;
                 }
+            }
+        }
+
+        private class NullOutputProvider : IOutputFileProvider
+        {
+            public TextWriter GetDebugFileWriter()
+            {
+                return null;
             }
         }
     }

--- a/test/Cle.Benchmarks/Compiler/CompilerDriverBenchmarks.cs
+++ b/test/Cle.Benchmarks/Compiler/CompilerDriverBenchmarks.cs
@@ -18,7 +18,7 @@ namespace Cle.Benchmarks.Compiler
         [Benchmark]
         public int CompileSingleFileWithSemanticError()
         {
-            var result = CompilerDriver.Compile(".", new CompilationOptions(), _almostSemanticallyValidSourceProvider);
+            var result = CompilerDriver.Compile(new CompilationOptions("."), _almostSemanticallyValidSourceProvider);
             return result.Diagnostics.Count;
         }
         

--- a/test/Cle.Compiler.UnitTests/CompilationTests.cs
+++ b/test/Cle.Compiler.UnitTests/CompilationTests.cs
@@ -230,7 +230,7 @@ namespace Cle.Compiler.UnitTests
             Assert.That(compilation.ReserveMethodSlot(), Is.EqualTo(0));
             Assert.That(compilation.ReserveMethodSlot(), Is.EqualTo(1));
 
-            var method = new CompiledMethod();
+            var method = new CompiledMethod("Test::Method");
             Assert.That(() => compilation.SetMethodBody(1, method), Throws.Nothing);
             Assert.That(compilation.GetMethodBody(1), Is.SameAs(method));
         }
@@ -250,7 +250,7 @@ namespace Cle.Compiler.UnitTests
         {
             var compilation = new Compilation();
             
-            var method = new CompiledMethod();
+            var method = new CompiledMethod("Test::Method");
             Assert.That(() => compilation.SetMethodBody(1, method), Throws.InstanceOf<ArgumentException>());
         }
 

--- a/test/Cle.Compiler.UnitTests/CompilerDriverTests.cs
+++ b/test/Cle.Compiler.UnitTests/CompilerDriverTests.cs
@@ -12,7 +12,7 @@ namespace Cle.Compiler.UnitTests
             var fileProvider = new TestingSourceFileProvider();
             fileProvider.Add(".", "main.cle", source);
 
-            var result = CompilerDriver.Compile(".", new CompilationOptions(), fileProvider);
+            var result = CompilerDriver.Compile(new CompilationOptions("."), fileProvider);
 
             Assert.That(result.FailedCount, Is.EqualTo(1));
             Assert.That(result.ModuleCount, Is.EqualTo(1));
@@ -35,7 +35,7 @@ public NonexistentType Main() {}";
             var fileProvider = new TestingSourceFileProvider();
             fileProvider.Add(".", "main.cle", source);
 
-            var result = CompilerDriver.Compile(".", new CompilationOptions(), fileProvider);
+            var result = CompilerDriver.Compile(new CompilationOptions("."), fileProvider);
 
             Assert.That(result.FailedCount, Is.EqualTo(1));
             Assert.That(result.ModuleCount, Is.EqualTo(1));
@@ -59,7 +59,7 @@ public bool TypeMismatch() { return 2; }";
             var fileProvider = new TestingSourceFileProvider();
             fileProvider.Add(".", "main.cle", source);
 
-            var result = CompilerDriver.Compile(".", new CompilationOptions(), fileProvider);
+            var result = CompilerDriver.Compile(new CompilationOptions("."), fileProvider);
 
             Assert.That(result.FailedCount, Is.EqualTo(1));
             Assert.That(result.ModuleCount, Is.EqualTo(1));
@@ -86,7 +86,7 @@ internal int32 IntFunction() {}";
             fileProvider.Add(".", "file1.cle", source1);
             fileProvider.Add(".", "file2.cle", source2);
 
-            var result = CompilerDriver.Compile(".", new CompilationOptions(), fileProvider);
+            var result = CompilerDriver.Compile(new CompilationOptions("."), fileProvider);
 
             Assert.That(result.FailedCount, Is.EqualTo(1));
             Assert.That(result.ModuleCount, Is.EqualTo(1));
@@ -108,7 +108,7 @@ internal int32 IntFunction() {}";
             var fileProvider = new TestingSourceFileProvider();
             fileProvider.Add(".", "main.cle", source1);
 
-            var result = CompilerDriver.Compile(".", new CompilationOptions(), fileProvider);
+            var result = CompilerDriver.Compile(new CompilationOptions("."), fileProvider);
 
             Assert.That(result.FailedCount, Is.EqualTo(1));
             Assert.That(result.ModuleCount, Is.EqualTo(1));
@@ -133,7 +133,7 @@ private int32 MuchBetterMain() { return 42; }";
             fileProvider.Add(".", "file1.cle", source1);
             fileProvider.Add(".", "file2.cle", source2);
 
-            var result = CompilerDriver.Compile(".", new CompilationOptions(), fileProvider);
+            var result = CompilerDriver.Compile(new CompilationOptions("."), fileProvider);
 
             Assert.That(result.FailedCount, Is.EqualTo(1));
             Assert.That(result.ModuleCount, Is.EqualTo(1));

--- a/test/Cle.Compiler.UnitTests/CompilerDriverTests.cs
+++ b/test/Cle.Compiler.UnitTests/CompilerDriverTests.cs
@@ -1,4 +1,5 @@
-﻿using Cle.Common;
+﻿using System.IO;
+using Cle.Common;
 using NUnit.Framework;
 
 namespace Cle.Compiler.UnitTests
@@ -9,21 +10,24 @@ namespace Cle.Compiler.UnitTests
         public void Compile_exits_on_parse_error()
         {
             const string source = @"namespace Test";
-            var fileProvider = new TestingSourceFileProvider();
-            fileProvider.Add(".", "main.cle", source);
+            var sourceProvider = new TestingSourceFileProvider();
+            sourceProvider.Add(".", "main.cle", source);
 
-            var result = CompilerDriver.Compile(new CompilationOptions("."), fileProvider);
+            using (var outputProvider = new TestingOutputFileProvider())
+            {
+                var result = CompilerDriver.Compile(new CompilationOptions("."), sourceProvider, outputProvider);
 
-            Assert.That(result.FailedCount, Is.EqualTo(1));
-            Assert.That(result.ModuleCount, Is.EqualTo(1));
-            Assert.That(result.SucceededCount, Is.EqualTo(0));
+                Assert.That(result.FailedCount, Is.EqualTo(1));
+                Assert.That(result.ModuleCount, Is.EqualTo(1));
+                Assert.That(result.SucceededCount, Is.EqualTo(0));
 
-            Assert.That(result.Diagnostics, Has.Exactly(1).Items);
-            Assert.That(result.Diagnostics[0].Code, Is.EqualTo(DiagnosticCode.ExpectedSemicolon));
-            Assert.That(result.Diagnostics[0].Position.Line, Is.EqualTo(1));
-            Assert.That(result.Diagnostics[0].Position.ByteInLine, Is.EqualTo(14));
-            Assert.That(result.Diagnostics[0].Module, Is.EqualTo("."));
-            Assert.That(result.Diagnostics[0].Filename, Is.EqualTo("main.cle"));
+                Assert.That(result.Diagnostics, Has.Exactly(1).Items);
+                Assert.That(result.Diagnostics[0].Code, Is.EqualTo(DiagnosticCode.ExpectedSemicolon));
+                Assert.That(result.Diagnostics[0].Position.Line, Is.EqualTo(1));
+                Assert.That(result.Diagnostics[0].Position.ByteInLine, Is.EqualTo(14));
+                Assert.That(result.Diagnostics[0].Module, Is.EqualTo("."));
+                Assert.That(result.Diagnostics[0].Filename, Is.EqualTo("main.cle"));
+            }
         }
 
         [Test]
@@ -32,22 +36,25 @@ namespace Cle.Compiler.UnitTests
             const string source = @"namespace Test;
 
 public NonexistentType Main() {}";
-            var fileProvider = new TestingSourceFileProvider();
-            fileProvider.Add(".", "main.cle", source);
+            var sourceProvider = new TestingSourceFileProvider();
+            sourceProvider.Add(".", "main.cle", source);
 
-            var result = CompilerDriver.Compile(new CompilationOptions("."), fileProvider);
+            using (var outputProvider = new TestingOutputFileProvider())
+            {
+                var result = CompilerDriver.Compile(new CompilationOptions("."), sourceProvider, outputProvider);
 
-            Assert.That(result.FailedCount, Is.EqualTo(1));
-            Assert.That(result.ModuleCount, Is.EqualTo(1));
-            Assert.That(result.SucceededCount, Is.EqualTo(0));
+                Assert.That(result.FailedCount, Is.EqualTo(1));
+                Assert.That(result.ModuleCount, Is.EqualTo(1));
+                Assert.That(result.SucceededCount, Is.EqualTo(0));
 
-            Assert.That(result.Diagnostics, Has.Exactly(1).Items);
-            Assert.That(result.Diagnostics[0].Code, Is.EqualTo(DiagnosticCode.TypeNotFound));
-            Assert.That(result.Diagnostics[0].Actual, Is.EqualTo("NonexistentType"));
-            Assert.That(result.Diagnostics[0].Position.Line, Is.EqualTo(3));
-            Assert.That(result.Diagnostics[0].Position.ByteInLine, Is.EqualTo(0));
-            Assert.That(result.Diagnostics[0].Module, Is.EqualTo("."));
-            Assert.That(result.Diagnostics[0].Filename, Is.EqualTo("main.cle"));
+                Assert.That(result.Diagnostics, Has.Exactly(1).Items);
+                Assert.That(result.Diagnostics[0].Code, Is.EqualTo(DiagnosticCode.TypeNotFound));
+                Assert.That(result.Diagnostics[0].Actual, Is.EqualTo("NonexistentType"));
+                Assert.That(result.Diagnostics[0].Position.Line, Is.EqualTo(3));
+                Assert.That(result.Diagnostics[0].Position.ByteInLine, Is.EqualTo(0));
+                Assert.That(result.Diagnostics[0].Module, Is.EqualTo("."));
+                Assert.That(result.Diagnostics[0].Filename, Is.EqualTo("main.cle"));
+            }
         }
 
         [Test]
@@ -56,23 +63,26 @@ public NonexistentType Main() {}";
             const string source = @"namespace Test;
 
 public bool TypeMismatch() { return 2; }";
-            var fileProvider = new TestingSourceFileProvider();
-            fileProvider.Add(".", "main.cle", source);
+            var sourceProvider = new TestingSourceFileProvider();
+            sourceProvider.Add(".", "main.cle", source);
 
-            var result = CompilerDriver.Compile(new CompilationOptions("."), fileProvider);
+            using (var outputProvider = new TestingOutputFileProvider())
+            {
+                var result = CompilerDriver.Compile(new CompilationOptions("."), sourceProvider, outputProvider);
 
-            Assert.That(result.FailedCount, Is.EqualTo(1));
-            Assert.That(result.ModuleCount, Is.EqualTo(1));
-            Assert.That(result.SucceededCount, Is.EqualTo(0));
+                Assert.That(result.FailedCount, Is.EqualTo(1));
+                Assert.That(result.ModuleCount, Is.EqualTo(1));
+                Assert.That(result.SucceededCount, Is.EqualTo(0));
 
-            Assert.That(result.Diagnostics, Has.Exactly(1).Items);
-            Assert.That(result.Diagnostics[0].Code, Is.EqualTo(DiagnosticCode.TypeMismatch));
-            Assert.That(result.Diagnostics[0].Actual, Is.EqualTo("int32"));
-            Assert.That(result.Diagnostics[0].Expected, Is.EqualTo("bool"));
-            Assert.That(result.Diagnostics[0].Position.Line, Is.EqualTo(3));
-            Assert.That(result.Diagnostics[0].Position.ByteInLine, Is.EqualTo(36));
-            Assert.That(result.Diagnostics[0].Module, Is.EqualTo("."));
-            Assert.That(result.Diagnostics[0].Filename, Is.EqualTo("main.cle"));
+                Assert.That(result.Diagnostics, Has.Exactly(1).Items);
+                Assert.That(result.Diagnostics[0].Code, Is.EqualTo(DiagnosticCode.TypeMismatch));
+                Assert.That(result.Diagnostics[0].Actual, Is.EqualTo("int32"));
+                Assert.That(result.Diagnostics[0].Expected, Is.EqualTo("bool"));
+                Assert.That(result.Diagnostics[0].Position.Line, Is.EqualTo(3));
+                Assert.That(result.Diagnostics[0].Position.ByteInLine, Is.EqualTo(36));
+                Assert.That(result.Diagnostics[0].Module, Is.EqualTo("."));
+                Assert.That(result.Diagnostics[0].Filename, Is.EqualTo("main.cle"));
+            }
         }
 
         [Test]
@@ -82,41 +92,47 @@ public bool TypeMismatch() { return 2; }";
 public int32 IntFunction() {}";
             const string source2 = @"namespace Test;
 internal int32 IntFunction() {}";
-            var fileProvider = new TestingSourceFileProvider();
-            fileProvider.Add(".", "file1.cle", source1);
-            fileProvider.Add(".", "file2.cle", source2);
+            var sourceProvider = new TestingSourceFileProvider();
+            sourceProvider.Add(".", "file1.cle", source1);
+            sourceProvider.Add(".", "file2.cle", source2);
 
-            var result = CompilerDriver.Compile(new CompilationOptions("."), fileProvider);
+            using (var outputProvider = new TestingOutputFileProvider())
+            {
+                var result = CompilerDriver.Compile(new CompilationOptions("."), sourceProvider, outputProvider);
 
-            Assert.That(result.FailedCount, Is.EqualTo(1));
-            Assert.That(result.ModuleCount, Is.EqualTo(1));
-            Assert.That(result.SucceededCount, Is.EqualTo(0));
+                Assert.That(result.FailedCount, Is.EqualTo(1));
+                Assert.That(result.ModuleCount, Is.EqualTo(1));
+                Assert.That(result.SucceededCount, Is.EqualTo(0));
 
-            Assert.That(result.Diagnostics, Has.Exactly(1).Items);
-            Assert.That(result.Diagnostics[0].Code, Is.EqualTo(DiagnosticCode.MethodAlreadyDefined));
-            Assert.That(result.Diagnostics[0].Actual, Is.EqualTo("Test::IntFunction"));
-            Assert.That(result.Diagnostics[0].Position.Line, Is.EqualTo(2));
-            Assert.That(result.Diagnostics[0].Position.ByteInLine, Is.EqualTo(0));
-            Assert.That(result.Diagnostics[0].Module, Is.EqualTo("."));
-            Assert.That(result.Diagnostics[0].Filename, Is.EqualTo("file2.cle"));
+                Assert.That(result.Diagnostics, Has.Exactly(1).Items);
+                Assert.That(result.Diagnostics[0].Code, Is.EqualTo(DiagnosticCode.MethodAlreadyDefined));
+                Assert.That(result.Diagnostics[0].Actual, Is.EqualTo("Test::IntFunction"));
+                Assert.That(result.Diagnostics[0].Position.Line, Is.EqualTo(2));
+                Assert.That(result.Diagnostics[0].Position.ByteInLine, Is.EqualTo(0));
+                Assert.That(result.Diagnostics[0].Module, Is.EqualTo("."));
+                Assert.That(result.Diagnostics[0].Filename, Is.EqualTo("file2.cle"));
+            }
         }
         
         [Test]
         public void Compile_exits_if_main_module_provides_no_entry_point()
         {
             const string source1 = @"namespace Test;";
-            var fileProvider = new TestingSourceFileProvider();
-            fileProvider.Add(".", "main.cle", source1);
+            var sourceProvider = new TestingSourceFileProvider();
+            sourceProvider.Add(".", "main.cle", source1);
 
-            var result = CompilerDriver.Compile(new CompilationOptions("."), fileProvider);
+            using (var outputProvider = new TestingOutputFileProvider())
+            {
+                var result = CompilerDriver.Compile(new CompilationOptions("."), sourceProvider, outputProvider);
 
-            Assert.That(result.FailedCount, Is.EqualTo(1));
-            Assert.That(result.ModuleCount, Is.EqualTo(1));
-            Assert.That(result.SucceededCount, Is.EqualTo(0));
+                Assert.That(result.FailedCount, Is.EqualTo(1));
+                Assert.That(result.ModuleCount, Is.EqualTo(1));
+                Assert.That(result.SucceededCount, Is.EqualTo(0));
 
-            Assert.That(result.Diagnostics, Has.Exactly(1).Items);
-            Assert.That(result.Diagnostics[0].Code, Is.EqualTo(DiagnosticCode.NoEntryPointProvided));
-            Assert.That(result.Diagnostics[0].Module, Is.EqualTo("."));
+                Assert.That(result.Diagnostics, Has.Exactly(1).Items);
+                Assert.That(result.Diagnostics[0].Code, Is.EqualTo(DiagnosticCode.NoEntryPointProvided));
+                Assert.That(result.Diagnostics[0].Module, Is.EqualTo("."));
+            }
         }
 
         // TODO: When the module system exists, a test should allow having entry points in separate modules
@@ -129,22 +145,25 @@ private int32 Main() { return 0; }";
             const string source2 = @"namespace Test::BetterFunctions;
 [EntryPoint]
 private int32 MuchBetterMain() { return 42; }";
-            var fileProvider = new TestingSourceFileProvider();
-            fileProvider.Add(".", "file1.cle", source1);
-            fileProvider.Add(".", "file2.cle", source2);
+            var sourceProvider = new TestingSourceFileProvider();
+            sourceProvider.Add(".", "file1.cle", source1);
+            sourceProvider.Add(".", "file2.cle", source2);
 
-            var result = CompilerDriver.Compile(new CompilationOptions("."), fileProvider);
+            using (var outputProvider = new TestingOutputFileProvider())
+            {
+                var result = CompilerDriver.Compile(new CompilationOptions("."), sourceProvider, outputProvider);
 
-            Assert.That(result.FailedCount, Is.EqualTo(1));
-            Assert.That(result.ModuleCount, Is.EqualTo(1));
-            Assert.That(result.SucceededCount, Is.EqualTo(0));
+                Assert.That(result.FailedCount, Is.EqualTo(1));
+                Assert.That(result.ModuleCount, Is.EqualTo(1));
+                Assert.That(result.SucceededCount, Is.EqualTo(0));
 
-            Assert.That(result.Diagnostics, Has.Exactly(1).Items);
-            Assert.That(result.Diagnostics[0].Code, Is.EqualTo(DiagnosticCode.MultipleEntryPointsProvided));
-            Assert.That(result.Diagnostics[0].Actual, Is.EqualTo("Test::BetterFunctions::MuchBetterMain"));
-            Assert.That(result.Diagnostics[0].Position.Line, Is.EqualTo(3));
-            Assert.That(result.Diagnostics[0].Module, Is.EqualTo("."));
-            Assert.That(result.Diagnostics[0].Filename, Is.EqualTo("file2.cle"));
+                Assert.That(result.Diagnostics, Has.Exactly(1).Items);
+                Assert.That(result.Diagnostics[0].Code, Is.EqualTo(DiagnosticCode.MultipleEntryPointsProvided));
+                Assert.That(result.Diagnostics[0].Actual, Is.EqualTo("Test::BetterFunctions::MuchBetterMain"));
+                Assert.That(result.Diagnostics[0].Position.Line, Is.EqualTo(3));
+                Assert.That(result.Diagnostics[0].Module, Is.EqualTo("."));
+                Assert.That(result.Diagnostics[0].Filename, Is.EqualTo("file2.cle"));
+            }
         }
 
         [Test]
@@ -154,13 +173,13 @@ private int32 MuchBetterMain() { return 42; }";
 private int32 PrivateFunc() {}
 internal bool ProtectedFunc() {}
 public void PublicFunc() {}";
-            var fileProvider = new TestingSourceFileProvider();
-            fileProvider.Add(".", "main.cle", source);
+            var sourceProvider = new TestingSourceFileProvider();
+            sourceProvider.Add(".", "main.cle", source);
 
             var compilation = new Compilation();
-            CompilerDriver.ParseModule(".", compilation, fileProvider, out var syntaxTrees);
+            CompilerDriver.ParseModule(".", compilation, sourceProvider, out var syntaxTrees);
 
-            fileProvider.AssertFileWasRead("main.cle");
+            sourceProvider.AssertFileWasRead("main.cle");
             Assert.That(compilation.Diagnostics, Is.Empty);
             Assert.That(syntaxTrees, Has.Exactly(1).Items);
         }
@@ -175,15 +194,15 @@ public void PublicFunc() {}";
             const string source2 = @"namespace Test;
 public int32 OneMoreFunc() {}";
 
-            var fileProvider = new TestingSourceFileProvider();
-            fileProvider.Add(".", "main.cle", source1);
-            fileProvider.Add(".", "other.cle", source2);
+            var sourceProvider = new TestingSourceFileProvider();
+            sourceProvider.Add(".", "main.cle", source1);
+            sourceProvider.Add(".", "other.cle", source2);
 
             var compilation = new Compilation();
-            CompilerDriver.ParseModule(".", compilation, fileProvider, out var syntaxTrees);
+            CompilerDriver.ParseModule(".", compilation, sourceProvider, out var syntaxTrees);
 
-            fileProvider.AssertFileWasRead("main.cle");
-            fileProvider.AssertFileWasRead("other.cle");
+            sourceProvider.AssertFileWasRead("main.cle");
+            sourceProvider.AssertFileWasRead("other.cle");
             Assert.That(compilation.Diagnostics, Is.Empty);
             Assert.That(syntaxTrees, Has.Exactly(2).Items);
         }
@@ -195,15 +214,15 @@ public int32 OneMoreFunc() {}";
             const string source2 = @"namespace Test;
 public int32 Func {}";
 
-            var fileProvider = new TestingSourceFileProvider();
-            fileProvider.Add(".", "main.cle", source1);
-            fileProvider.Add(".", "other.cle", source2);
+            var sourceProvider = new TestingSourceFileProvider();
+            sourceProvider.Add(".", "main.cle", source1);
+            sourceProvider.Add(".", "other.cle", source2);
 
             var compilation = new Compilation();
-            CompilerDriver.ParseModule(".", compilation, fileProvider, out var syntaxTrees);
+            CompilerDriver.ParseModule(".", compilation, sourceProvider, out var syntaxTrees);
 
-            fileProvider.AssertFileWasRead("main.cle");
-            fileProvider.AssertFileWasRead("other.cle");
+            sourceProvider.AssertFileWasRead("main.cle");
+            sourceProvider.AssertFileWasRead("other.cle");
             Assert.That(compilation.Diagnostics, Has.Exactly(2).Items);
             Assert.That(syntaxTrees, Is.Empty);
 
@@ -219,11 +238,11 @@ public int32 Func {}";
         [Test]
         public void ParseModule_raises_error_on_unavailable_source_file()
         {
-            var fileProvider = new TestingSourceFileProvider();
-            fileProvider.Add(".", "main.cle", null);
+            var sourceProvider = new TestingSourceFileProvider();
+            sourceProvider.Add(".", "main.cle", null);
 
             var compilation = new Compilation();
-            CompilerDriver.ParseModule(".", compilation, fileProvider, out var syntaxTrees);
+            CompilerDriver.ParseModule(".", compilation, sourceProvider, out var syntaxTrees);
             
             Assert.That(compilation.Diagnostics, Has.Exactly(1).Items);
             Assert.That(compilation.Diagnostics[0].Code, Is.EqualTo(DiagnosticCode.SourceFileNotFound));
@@ -234,16 +253,55 @@ public int32 Func {}";
         [Test]
         public void ParseModule_raises_error_on_unavailable_module()
         {
-            var fileProvider = new TestingSourceFileProvider();
-            fileProvider.Add(".", "main.cle", "");
+            var sourceProvider = new TestingSourceFileProvider();
+            sourceProvider.Add(".", "main.cle", "");
 
             var compilation = new Compilation();
-            CompilerDriver.ParseModule("OtherModule", compilation, fileProvider, out var syntaxTrees);
+            CompilerDriver.ParseModule("OtherModule", compilation, sourceProvider, out var syntaxTrees);
             
             Assert.That(compilation.Diagnostics, Has.Exactly(1).Items);
             Assert.That(compilation.Diagnostics[0].Code, Is.EqualTo(DiagnosticCode.ModuleNotFound));
             Assert.That(compilation.Diagnostics[0].Module, Is.EqualTo("OtherModule"));
             Assert.That(syntaxTrees, Is.Empty);
+        }
+
+        [Test]
+        public void Debug_logging_is_written()
+        {
+            const string source = @"namespace Test;
+public bool SimpleMethod() { return true; }
+public int32 ComplexMethod() { return 42; }";
+            var sourceProvider = new TestingSourceFileProvider();
+            sourceProvider.Add(".", "main.cle", source);
+
+            using (var outputProvider = new TestingOutputFileProvider())
+            {
+                var result = CompilerDriver.Compile(new CompilationOptions(".", debugPattern: "Simple"),
+                    sourceProvider, outputProvider);
+
+                var writer = outputProvider.DebugWriter;
+                Assert.That(writer.ToString(), Does.Contain("; Test::SimpleMethod"));
+                Assert.That(writer.ToString(), Does.Contain("  Return #0"));
+                Assert.That(writer.ToString(), Does.Not.Contain("ComplexMethod"));
+            }
+        }
+
+        [Test]
+        public void Debug_log_is_not_created_if_logging_is_disabled()
+        {
+            const string source = @"namespace Test;
+public bool SimpleMethod() { return true; }
+public int32 ComplexMethod() { return 42; }";
+            var sourceProvider = new TestingSourceFileProvider();
+            sourceProvider.Add(".", "main.cle", source);
+
+            using (var outputProvider = new TestingOutputFileProvider())
+            {
+                var result = CompilerDriver.Compile(new CompilationOptions("."),
+                    sourceProvider, outputProvider);
+
+                Assert.That(outputProvider.DebugWriter, Is.Null);
+            }
         }
     }
 }

--- a/test/Cle.Compiler.UnitTests/DebugLoggerTests.cs
+++ b/test/Cle.Compiler.UnitTests/DebugLoggerTests.cs
@@ -1,0 +1,111 @@
+﻿using System.IO;
+using Cle.SemanticAnalysis.IR;
+using NUnit.Framework;
+
+namespace Cle.Compiler.UnitTests
+{
+    public class DebugLoggerTests
+    {
+        [Test]
+        public void Method_name_is_matched()
+        {
+            var writer = new StringWriter();
+            var logger = new DebugLogger(writer, "a"); // Match names containing "a"
+            
+            Assert.That(logger.ShouldLog("a"), Is.True);
+            Assert.That(logger.ShouldLog("A"), Is.True); // Case-insensitivity
+            Assert.That(logger.ShouldLog("Long::Namespace::Name::Function"), Is.True);
+            Assert.That(logger.ShouldLog("function2"), Is.False);
+        }
+
+        [Test]
+        public void Wildcard_matches_all_methods()
+        {
+            var writer = new StringWriter();
+            var logger = new DebugLogger(writer, "*");
+            
+            Assert.That(logger.ShouldLog("a"), Is.True);
+            Assert.That(logger.ShouldLog("Long::Namespace::Name::Function"), Is.True);
+            Assert.That(logger.ShouldLog("function2"), Is.True);
+        }
+
+        [Test]
+        public void Null_writer_disables_logging()
+        {
+            var logger = new DebugLogger(null, "*");
+
+            Assert.That(logger.ShouldLog("a"), Is.False);
+            Assert.That(() => logger.WriteHeader("a"), Throws.Nothing);
+            Assert.That(() => logger.WriteLine("a"), Throws.Nothing);
+            Assert.That(() => logger.DumpMethod(new CompiledMethod("a")), Throws.Nothing);
+        }
+
+        [Test]
+        public void Null_writer_and_null_pattern_disable_logging()
+        {
+            var logger = new DebugLogger(null, null);
+
+            Assert.That(logger.ShouldLog("a"), Is.False);
+            Assert.That(() => logger.WriteHeader("a"), Throws.Nothing);
+            Assert.That(() => logger.WriteLine("a"), Throws.Nothing);
+            Assert.That(() => logger.DumpMethod(new CompiledMethod("a")), Throws.Nothing);
+        }
+
+        [Test]
+        public void Null_pattern_logs_error_and_matches_nothing()
+        {
+            var writer = new StringWriter();
+            var logger = new DebugLogger(writer, null);
+
+            Assert.That(logger.ShouldLog("a"), Is.False);
+            Assert.That(writer.ToString(), Is.Not.Empty);
+
+            logger.WriteLine("!!!");
+            Assert.That(writer.ToString(), Does.Contain("!!!"));
+        }
+
+        [Test]
+        public void Writing_headers_and_text_succeeds()
+        {
+            var writer = new StringWriter();
+            var logger = new DebugLogger(writer, "*");
+
+            logger.WriteHeader("This is a header");
+            logger.WriteLine("This is a line");
+
+            Assert.That(writer.ToString(), Is.EqualTo(@"
+
+## This is a header
+
+This is a line
+"));
+        }
+
+        [Test]
+        public void DumpMethod_does_not_dump_non_matching_method()
+        {
+            var writer = new StringWriter();
+            var logger = new DebugLogger(writer, "Namespace::");
+            var method = new CompiledMethod("other::method");
+
+            logger.DumpMethod(method);
+
+            Assert.That(writer.ToString(), Is.Empty);
+        }
+
+        [Test]
+        public void DumpMethod_dumps_matching_method_without_body()
+        {
+            var writer = new StringWriter();
+            var logger = new DebugLogger(writer, "*");
+            var method = new CompiledMethod("Namespace::Method");
+
+            logger.DumpMethod(method);
+
+            Assert.That(writer.ToString(), Does.Contain("; Namespace::Method"));
+            Assert.That(writer.ToString(), Does.Contain("; (Method has no body)"));
+        }
+
+        // DumpMethod with body is tested in CompilerDriverTests because a method body is hard to mock
+    }
+}

--- a/test/Cle.Compiler.UnitTests/TestingOutputFileProvider.cs
+++ b/test/Cle.Compiler.UnitTests/TestingOutputFileProvider.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.IO;
+
+namespace Cle.Compiler.UnitTests
+{
+    internal class TestingOutputFileProvider : IOutputFileProvider, IDisposable
+    {
+        /// <summary>
+        /// Gets the mock debug log writer.
+        /// Null if never requested via <see cref="GetDebugFileWriter"/>.
+        /// </summary>
+        public StringWriter DebugWriter { get; private set; }
+
+        public void Dispose()
+        {
+            DebugWriter?.Dispose();
+        }
+
+        public TextWriter GetDebugFileWriter()
+        {
+            if (DebugWriter is null)
+            {
+                DebugWriter = new StringWriter();
+            }
+
+            return DebugWriter;
+        }
+    }
+}

--- a/test/Cle.Frontend.UnitTests/Cle.Frontend.UnitTests.csproj
+++ b/test/Cle.Frontend.UnitTests/Cle.Frontend.UnitTests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <LangVersion>7.3</LangVersion>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" Version="2018.2.1" />
+    <PackageReference Include="nunit" Version="3.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Cle.Frontend\Cle.Frontend.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Cle.Frontend.UnitTests/CommandLineParserTests.cs
+++ b/test/Cle.Frontend.UnitTests/CommandLineParserTests.cs
@@ -1,0 +1,73 @@
+using System.IO;
+using NUnit.Framework;
+
+namespace Cle.Frontend.UnitTests
+{
+    public class CommandLineParserTests
+    {
+        [Test]
+        public void Version_is_displayed_when_version_flag_is_passed()
+        {
+            var output = new StringWriter();
+
+            // The CommandLineParser library (not same as the class under test)
+            // prints "testhost m.n.o" when running the test suite...
+            Assert.That(CommandLineParser.TryParseArguments(new[] { "--version" }, output, out var _), Is.False);
+            Assert.That(output.ToString(), Does.Contain("."));
+        }
+
+        [Test]
+        public void Help_is_displayed_when_requested()
+        {
+            var output = new StringWriter();
+            
+            Assert.That(CommandLineParser.TryParseArguments(new[] { "--help" }, output, out var _), Is.False);
+            Assert.That(output.ToString(), Does.Contain("--help"));
+        }
+
+        [Test]
+        public void Dump_regex_is_parsed()
+        {
+            var output = new StringWriter();
+            
+            // The real command line could be wrapped in quotes, but that is already handled when Main gets the args.
+            Assert.That(CommandLineParser.TryParseArguments(new[] { "--dump", "\\d+" }, output, out var options),
+                Is.True);
+            Assert.That(options, Is.Not.Null);
+            Assert.That(options.DebugPattern, Is.EqualTo("\\d+"));
+            Assert.That(options.DebugOutput, Is.True);
+        }
+
+        [Test]
+        public void Main_module_is_current_directory_by_default()
+        {
+            var output = new StringWriter();
+            
+            Assert.That(CommandLineParser.TryParseArguments(new string[] { }, output, out var options),
+                Is.True);
+            Assert.That(options, Is.Not.Null);
+            Assert.That(options.MainModule, Is.EqualTo("."));
+        }
+
+        [Test]
+        public void Main_module_can_be_overridden()
+        {
+            var output = new StringWriter();
+            
+            Assert.That(CommandLineParser.TryParseArguments(new[] { "MainModule" }, output, out var options),
+                Is.True);
+            Assert.That(options, Is.Not.Null);
+            Assert.That(options.MainModule, Is.EqualTo("MainModule"));
+        }
+
+        [Test]
+        public void Main_module_can_not_be_specified_twice()
+        {
+            var output = new StringWriter();
+            
+            Assert.That(CommandLineParser.TryParseArguments(new[] { "Main1", "Main2" }, output, out var options),
+                Is.False);
+            Assert.That(options, Is.Null);
+        }
+    }
+}

--- a/test/Cle.Frontend.UnitTests/OutputFileProviderTests.cs
+++ b/test/Cle.Frontend.UnitTests/OutputFileProviderTests.cs
@@ -1,0 +1,39 @@
+using System.IO;
+using NUnit.Framework;
+
+namespace Cle.Frontend.UnitTests
+{
+    public class OutputFileProviderTests
+    {
+        private const string DumpFileName = "cle-dump.txt";
+
+        [Test]
+        public void GetDebugFileWriter_returns_writer()
+        {
+            using (var provider = new OutputFileProvider(Directory.GetCurrentDirectory()))
+            {
+                var writer = provider.GetDebugFileWriter();
+                Assert.That(writer, Is.Not.Null);
+                Assert.That(File.Exists(DumpFileName), Is.True);
+
+                // The call should be idempotent
+                Assert.That(provider.GetDebugFileWriter(), Is.SameAs(writer));
+            }
+
+            File.Delete(DumpFileName);
+        }
+
+        [Test]
+        public void GetDebugFileWriter_returns_null_if_file_cannot_be_created()
+        {
+            using (var blockingFile = File.Create(DumpFileName))
+            {
+                using (var provider = new OutputFileProvider(Directory.GetCurrentDirectory()))
+                {
+                    Assert.That(provider.GetDebugFileWriter(), Is.Null);
+                }
+            }
+            File.Delete(DumpFileName);
+        }
+    }
+}

--- a/test/Cle.Frontend.UnitTests/SourceFileProviderTests.cs
+++ b/test/Cle.Frontend.UnitTests/SourceFileProviderTests.cs
@@ -1,0 +1,92 @@
+using System.IO;
+using NUnit.Framework;
+
+namespace Cle.Frontend.UnitTests
+{
+    public class SourceFileProviderTests
+    {
+        private const string ModuleName = "SourceFileProviderTestCases";
+
+        [OneTimeSetUp]
+        public void SetUpFolderStructure()
+        {
+            Directory.Delete(ModuleName, true);
+            Directory.CreateDirectory(ModuleName);
+            var skippedFolder = Path.Combine(ModuleName, "ToBeSkipped");
+            Directory.CreateDirectory(skippedFolder);
+
+            using (var file = File.CreateText(Path.Combine(ModuleName, "file2.cle")))
+            {
+                file.Write("content");
+            }
+            using (File.Create(Path.Combine(ModuleName, "file1.cle"))) { }
+            using (File.Create(Path.Combine(ModuleName, "ignored.notcle"))) { }
+            using (File.Create(Path.Combine(skippedFolder, "ignored.cle"))) { }
+        }
+
+        [Test]
+        public void Files_are_searched_in_default_directory_and_not_subdirectories()
+        {
+            var provider = new SourceFileProvider(Path.GetFullPath(ModuleName));
+
+            Assert.That(provider.TryGetFilenamesForModule(".", out var filenames), Is.True);
+
+            // The order must be fixed, and only .cle files in the exact directory must be found
+            var expected1 = Path.GetFullPath(Path.Combine(ModuleName, "file1.cle"));
+            var expected2 = Path.GetFullPath(Path.Combine(ModuleName, "file2.cle"));
+            CollectionAssert.AreEqual(new[] { expected1, expected2 }, filenames);
+        }
+
+        [Test]
+        public void Files_are_searched_in_specified_directory_and_not_subdirectories()
+        {
+            var provider = new SourceFileProvider(Directory.GetCurrentDirectory());
+
+            Assert.That(provider.TryGetFilenamesForModule(ModuleName, out var filenames), Is.True);
+            var expected1 = Path.GetFullPath(Path.Combine(ModuleName, "file1.cle"));
+            var expected2 = Path.GetFullPath(Path.Combine(ModuleName, "file2.cle"));
+            CollectionAssert.AreEqual(new[] { expected1, expected2 }, filenames);
+        }
+
+        [Test]
+        public void Getting_filenames_fails_for_nonexistent_path()
+        {
+            var provider = new SourceFileProvider(Directory.GetCurrentDirectory());
+
+            Assert.That(provider.TryGetFilenamesForModule("Nonexistent", out var _), Is.False);
+        }
+
+        [Test]
+        public void Getting_file_contents_succeeds()
+        {
+            var provider = new SourceFileProvider(Directory.GetCurrentDirectory());
+
+            var filename = Path.Combine(Directory.GetCurrentDirectory(), ModuleName, "file2.cle");
+            Assert.That(provider.TryGetSourceFile(filename, out var bytes), Is.True);
+            Assert.That(bytes.Length, Is.EqualTo(7));
+        }
+
+        [Test]
+        public void Getting_file_contents_fails_if_file_does_not_exist()
+        {
+            var provider = new SourceFileProvider(ModuleName);
+
+            Assert.That(provider.TryGetSourceFile("nonexistent.cle", out var _), Is.False);
+        }
+
+        [Test]
+        public void Getting_file_contents_fails_if_file_is_in_use()
+        {
+            var provider = new SourceFileProvider(ModuleName);
+
+            var path = Path.Combine(ModuleName, "InUse");
+            Directory.CreateDirectory(path);
+            var filename = Path.Combine(path, "inuse.cle");
+            using (File.Create(filename))
+            {
+                Assert.That(provider.TryGetSourceFile(filename, out var _), Is.False);
+            }
+
+        }
+    }
+}

--- a/test/Cle.Frontend.UnitTests/SourceFileProviderTests.cs
+++ b/test/Cle.Frontend.UnitTests/SourceFileProviderTests.cs
@@ -10,7 +10,14 @@ namespace Cle.Frontend.UnitTests
         [OneTimeSetUp]
         public void SetUpFolderStructure()
         {
-            Directory.Delete(ModuleName, true);
+            // Clean up the directory structure from previous runs or other sources.
+            // The Directory.Exists check is not thread-safe, but we already assume that
+            // nobody is messing with our test data directory.
+            if (Directory.Exists(ModuleName))
+            {
+                Directory.Delete(ModuleName, true);
+            }
+
             Directory.CreateDirectory(ModuleName);
             var skippedFolder = Path.Combine(ModuleName, "ToBeSkipped");
             Directory.CreateDirectory(skippedFolder);

--- a/test/Cle.SemanticAnalysis.UnitTests/CompiledMethodTests.cs
+++ b/test/Cle.SemanticAnalysis.UnitTests/CompiledMethodTests.cs
@@ -9,7 +9,7 @@ namespace Cle.SemanticAnalysis.UnitTests
         [Test]
         public void CreateLocal_succeeds_for_int32()
         {
-            var method = new CompiledMethod();
+            var method = new CompiledMethod("Test::Method");
 
             Assert.That(method.AddLocal(SimpleType.Int32, ConstantValue.SignedInteger(1)), Is.EqualTo(0));
             Assert.That(method.AddLocal(SimpleType.Int32, ConstantValue.SignedInteger(-17)), Is.EqualTo(1));
@@ -24,7 +24,7 @@ namespace Cle.SemanticAnalysis.UnitTests
         [Test]
         public void CreateLocal_succeeds_for_bool()
         {
-            var method = new CompiledMethod();
+            var method = new CompiledMethod("Test::Method");
 
             Assert.That(method.AddLocal(SimpleType.Bool, ConstantValue.Bool(true)), Is.EqualTo(0));
             Assert.That(method.AddLocal(SimpleType.Bool, ConstantValue.Bool(false)), Is.EqualTo(1));

--- a/test/Cle.SemanticAnalysis.UnitTests/ExpressionCompilerTests.cs
+++ b/test/Cle.SemanticAnalysis.UnitTests/ExpressionCompilerTests.cs
@@ -16,7 +16,7 @@ namespace Cle.SemanticAnalysis.UnitTests
         public void Integer_literal_stored_in_int32_succeeds()
         {
             var syntax = new IntegerLiteralSyntax(1234, default);
-            var method = new CompiledMethod();
+            var method = new CompiledMethod("Test::Method");
             var builder = new BasicBlockGraphBuilder().GetInitialBlockBuilder();
             var variableMap = new ScopedVariableMap();
             var diagnostics = new TestingDiagnosticSink();
@@ -38,7 +38,7 @@ namespace Cle.SemanticAnalysis.UnitTests
         {
             var position = new TextPosition(10, 3, 4);
             var syntax = new IntegerLiteralSyntax(1234, position);
-            var method = new CompiledMethod();
+            var method = new CompiledMethod("Test::Method");
             var builder = new BasicBlockGraphBuilder().GetInitialBlockBuilder();
             var variableMap = new ScopedVariableMap();
             var diagnostics = new TestingDiagnosticSink();
@@ -57,7 +57,7 @@ namespace Cle.SemanticAnalysis.UnitTests
         {
             var position = new TextPosition(10, 3, 4);
             var syntax = new IntegerLiteralSyntax((ulong)int.MaxValue + 1, position);
-            var method = new CompiledMethod();
+            var method = new CompiledMethod("Test::Method");
             var builder = new BasicBlockGraphBuilder().GetInitialBlockBuilder();
             var variableMap = new ScopedVariableMap();
             var diagnostics = new TestingDiagnosticSink();
@@ -74,7 +74,7 @@ namespace Cle.SemanticAnalysis.UnitTests
         public void Boolean_literal_stored_in_bool_succeeds()
         {
             var syntax = new BooleanLiteralSyntax(true, default);
-            var method = new CompiledMethod();
+            var method = new CompiledMethod("Test::Method");
             var builder = new BasicBlockGraphBuilder().GetInitialBlockBuilder();
             var variableMap = new ScopedVariableMap();
             var diagnostics = new TestingDiagnosticSink();
@@ -95,7 +95,7 @@ namespace Cle.SemanticAnalysis.UnitTests
         public void Variable_reference_returns_local_index_of_variable()
         {
             var syntax = new NamedValueSyntax("a", default);
-            var method = new CompiledMethod();
+            var method = new CompiledMethod("Test::Method");
             var builder = new BasicBlockGraphBuilder().GetInitialBlockBuilder();
             var diagnostics = new TestingDiagnosticSink();
 
@@ -116,7 +116,7 @@ namespace Cle.SemanticAnalysis.UnitTests
         {
             var position = new TextPosition(10, 3, 4);
             var syntax = new NamedValueSyntax("a", position);
-            var method = new CompiledMethod();
+            var method = new CompiledMethod("Test::Method");
             var builder = new BasicBlockGraphBuilder().GetInitialBlockBuilder();
             var diagnostics = new TestingDiagnosticSink();
 
@@ -138,7 +138,7 @@ namespace Cle.SemanticAnalysis.UnitTests
         {
             var position = new TextPosition(10, 3, 4);
             var syntax = new NamedValueSyntax("a", position);
-            var method = new CompiledMethod();
+            var method = new CompiledMethod("Test::Method");
             var builder = new BasicBlockGraphBuilder().GetInitialBlockBuilder();
             var diagnostics = new TestingDiagnosticSink();
             var variableMap = new ScopedVariableMap();
@@ -164,7 +164,7 @@ namespace Cle.SemanticAnalysis.UnitTests
         public void Int32_constant_expression_compiled_successfully(string expressionString, int expectedValue)
         {
             var expressionSyntax = ParseExpression(expressionString);
-            var method = new CompiledMethod();
+            var method = new CompiledMethod("Test::Method");
             var builder = new BasicBlockGraphBuilder().GetInitialBlockBuilder();
             var diagnostics = new TestingDiagnosticSink();
             var variableMap = new ScopedVariableMap();
@@ -185,7 +185,7 @@ namespace Cle.SemanticAnalysis.UnitTests
         public void Int32_non_constant_binary_expression_compiled_successfully(string expressionString, Opcode expectedOp)
         {
             var expressionSyntax = ParseExpression(expressionString);
-            var method = new CompiledMethod();
+            var method = new CompiledMethod("Test::Method");
             var builder = new BasicBlockGraphBuilder().GetInitialBlockBuilder();
             var diagnostics = new TestingDiagnosticSink();
             var variableMap = new ScopedVariableMap();
@@ -211,7 +211,7 @@ namespace Cle.SemanticAnalysis.UnitTests
         public void Int32_non_constant_unary_expression_compiled_successfully(string expressionString, Opcode expectedOp)
         {
             var expressionSyntax = ParseExpression(expressionString);
-            var method = new CompiledMethod();
+            var method = new CompiledMethod("Test::Method");
             var builder = new BasicBlockGraphBuilder().GetInitialBlockBuilder();
             var diagnostics = new TestingDiagnosticSink();
             var variableMap = new ScopedVariableMap();
@@ -241,7 +241,7 @@ namespace Cle.SemanticAnalysis.UnitTests
         public void Type_error_in_constant_expression(string expressionString)
         {
             var expressionSyntax = ParseExpression(expressionString);
-            var method = new CompiledMethod();
+            var method = new CompiledMethod("Test::Method");
             var builder = new BasicBlockGraphBuilder().GetInitialBlockBuilder();
             var diagnostics = new TestingDiagnosticSink();
             var variableMap = new ScopedVariableMap();
@@ -259,7 +259,7 @@ namespace Cle.SemanticAnalysis.UnitTests
         public void Failure_in_inner_expression_is_bubbled_up(string expressionString)
         {
             var expressionSyntax = ParseExpression(expressionString);
-            var method = new CompiledMethod();
+            var method = new CompiledMethod("Test::Method");
             var builder = new BasicBlockGraphBuilder().GetInitialBlockBuilder();
             var diagnostics = new TestingDiagnosticSink();
             var variableMap = new ScopedVariableMap();
@@ -279,7 +279,7 @@ namespace Cle.SemanticAnalysis.UnitTests
                 new IntegerLiteralSyntax(2ul, default), 
                 new IntegerLiteralSyntax(0, default), 
                 position);
-            var method = new CompiledMethod();
+            var method = new CompiledMethod("Test::Method");
             var builder = new BasicBlockGraphBuilder().GetInitialBlockBuilder();
             var diagnostics = new TestingDiagnosticSink();
             var variableMap = new ScopedVariableMap();
@@ -299,7 +299,7 @@ namespace Cle.SemanticAnalysis.UnitTests
                 new NamedValueSyntax("a", default), 
                 new IntegerLiteralSyntax(0, default),
                 position);
-            var method = new CompiledMethod();
+            var method = new CompiledMethod("Test::Method");
             var builder = new BasicBlockGraphBuilder().GetInitialBlockBuilder();
             var diagnostics = new TestingDiagnosticSink();
             var variableMap = new ScopedVariableMap();
@@ -320,7 +320,7 @@ namespace Cle.SemanticAnalysis.UnitTests
             var syntax = new UnaryExpressionSyntax(UnaryOperation.Minus,
                 new IntegerLiteralSyntax(2_147_483_649, default), // One less than smallest int32
                 position);
-            var method = new CompiledMethod();
+            var method = new CompiledMethod("Test::Method");
             var builder = new BasicBlockGraphBuilder().GetInitialBlockBuilder();
             var diagnostics = new TestingDiagnosticSink();
             var variableMap = new ScopedVariableMap();

--- a/test/Cle.SemanticAnalysis.UnitTests/MethodDisassemblerTests.cs
+++ b/test/Cle.SemanticAnalysis.UnitTests/MethodDisassemblerTests.cs
@@ -12,7 +12,7 @@ namespace Cle.SemanticAnalysis.UnitTests
         {
             var graphBuilder = new BasicBlockGraphBuilder();
             graphBuilder.GetInitialBlockBuilder().AppendInstruction(Opcode.Return, 0, 0, 0);
-            var method = new CompiledMethod { Body = graphBuilder.Build() };
+            var method = new CompiledMethod("Test::Method") { Body = graphBuilder.Build() };
             method.AddLocal(SimpleType.Int32, ConstantValue.SignedInteger(17));
             method.AddLocal(SimpleType.Bool, ConstantValue.Bool(true));
 
@@ -31,7 +31,7 @@ namespace Cle.SemanticAnalysis.UnitTests
         {
             var graphBuilder = new BasicBlockGraphBuilder();
             graphBuilder.GetInitialBlockBuilder().AppendInstruction(Opcode.Return, 2, 0, 0);
-            var method = new CompiledMethod { Body = graphBuilder.Build() };
+            var method = new CompiledMethod("Test::Method") { Body = graphBuilder.Build() };
 
             const string expected = "BB_0:\n    Return #2\n\n";
 
@@ -54,7 +54,7 @@ namespace Cle.SemanticAnalysis.UnitTests
             blockBuilder.AppendInstruction(Opcode.Divide, 1, 0, 2);
             blockBuilder.AppendInstruction(Opcode.ArithmeticNegate, 1, 0, 2);
             blockBuilder.AppendInstruction(Opcode.Return, 2, 0, 0);
-            var method = new CompiledMethod { Body = graphBuilder.Build() };
+            var method = new CompiledMethod("Test::Method") { Body = graphBuilder.Build() };
 
             const string expected = "BB_0:\n" +
                                     "    CopyValue #1 -> #2\n" +
@@ -77,7 +77,7 @@ namespace Cle.SemanticAnalysis.UnitTests
             var initialBlockBuilder = graphBuilder.GetInitialBlockBuilder();
             initialBlockBuilder.AppendInstruction(Opcode.Return, 0, 0, 0);
             initialBlockBuilder.CreateSuccessorBlock(); // No reference will be made and this will become null in Build()
-            var method = new CompiledMethod { Body = graphBuilder.Build() };
+            var method = new CompiledMethod("Test::Method") { Body = graphBuilder.Build() };
 
             const string expected = "BB_0:\n    Return #0\n\n";
 
@@ -91,7 +91,7 @@ namespace Cle.SemanticAnalysis.UnitTests
         {
             var graphBuilder = new BasicBlockGraphBuilder();
             graphBuilder.GetInitialBlockBuilder().SetSuccessor(0);
-            var method = new CompiledMethod { Body = graphBuilder.Build() };
+            var method = new CompiledMethod("Test::Method") { Body = graphBuilder.Build() };
 
             const string expected = "BB_0:\n    ==> BB_0\n\n";
 
@@ -105,7 +105,7 @@ namespace Cle.SemanticAnalysis.UnitTests
         {
             var graphBuilder = new BasicBlockGraphBuilder();
             graphBuilder.GetInitialBlockBuilder().CreateSuccessorBlock().SetSuccessor(0);
-            var method = new CompiledMethod { Body = graphBuilder.Build() };
+            var method = new CompiledMethod("Test::Method") { Body = graphBuilder.Build() };
 
             // Fallthrough from BB_0 to BB_1 is not explicitly displayed
             const string expected = "BB_0:\n\nBB_1:\n    ==> BB_0\n\n";
@@ -128,7 +128,7 @@ namespace Cle.SemanticAnalysis.UnitTests
             var returnBuilder = firstBuilder.CreateBranch(1);
             returnBuilder.AppendInstruction(Opcode.Return, 0, 0, 0);
 
-            var method = new CompiledMethod { Body = graphBuilder.Build() };
+            var method = new CompiledMethod("Test::Method") { Body = graphBuilder.Build() };
 
             // ...and the fallthrough from BB_0 to BB_1 is not explicitly displayed.
             const string expected = "BB_0:\n    BranchIf #1 ==> BB_2\n\n" +
@@ -153,7 +153,7 @@ namespace Cle.SemanticAnalysis.UnitTests
             loopBuilder.AppendInstruction(Opcode.Nop, 0, 0, 0);
             loopBuilder.SetSuccessor(0);
 
-            var method = new CompiledMethod { Body = graphBuilder.Build() };
+            var method = new CompiledMethod("Test::Method") { Body = graphBuilder.Build() };
 
             // ...and both successors are displayed.
             const string expected = "BB_0:\n    BranchIf #1 ==> BB_1\n    ==> BB_2\n\n" +


### PR DESCRIPTION
Closes #9.

The command line parsing is implemented with https://github.com/commandlineparser/commandline . I also experimented with `McMaster.Extensions.CommandLineUtils` and `System.CommandLine`, but this seemed the best library for the potentially large number of command line options. The user-facing error messages are a bit bad, though:
```
A sequence value not bound to option name is defined with few items than required.
```

Also implemented initial debug dumping.

Will hold off merging this until I can get a bit more testing and code coverage numbers.