### PR TITLE
Implement SSA conversion

### DIFF
--- a/src/Cle.Common/TypeSystem/ConstantValue.cs
+++ b/src/Cle.Common/TypeSystem/ConstantValue.cs
@@ -48,11 +48,19 @@ namespace Cle.Common.TypeSystem
         }
 
         /// <summary>
-        /// Creates a new void constant.
+        /// Creates a new void/uninitialized constant that is not a method parameter.
         /// </summary>
         public static ConstantValue Void()
         {
             return new ConstantValue(ConstantType.Void, 0);
+        }
+
+        /// <summary>
+        /// Creates a new constant that signifies a method parameter.
+        /// </summary>
+        public static ConstantValue Parameter()
+        {
+            return new ConstantValue(ConstantType.Parameter, 0);
         }
 
         private ConstantValue(ConstantType type, ulong data)
@@ -85,6 +93,8 @@ namespace Cle.Common.TypeSystem
             {
                 case ConstantType.Void:
                     return "void";
+                case ConstantType.Parameter:
+                    return "param";
                 case ConstantType.Boolean:
                     return _data == 1 ? "true" : "false";
                 case ConstantType.SignedInteger:
@@ -113,6 +123,7 @@ namespace Cle.Common.TypeSystem
     {
         Invalid,
         Void,
+        Parameter,
         Boolean,
         SignedInteger
     }

--- a/src/Cle.Common/TypeSystem/ConstantValue.cs
+++ b/src/Cle.Common/TypeSystem/ConstantValue.cs
@@ -32,6 +32,12 @@ namespace Cle.Common.TypeSystem
         public long AsSignedInteger => (long)_data;
 
         /// <summary>
+        /// Gets the value of this constant as an unsigned integer.
+        /// <see cref="Type"/> is not checked.
+        /// </summary>
+        public ulong AsUnsignedInteger => _data;
+
+        /// <summary>
         /// Creates a new boolean constant with the specified value.
         /// </summary>
         public static ConstantValue Bool(bool value)

--- a/src/Cle.SemanticAnalysis/IR/BasicBlock.cs
+++ b/src/Cle.SemanticAnalysis/IR/BasicBlock.cs
@@ -15,6 +15,12 @@ namespace Cle.SemanticAnalysis.IR
         public ImmutableList<Instruction> Instructions { get; }
 
         /// <summary>
+        /// Gets the Phi nodes in this basic block.
+        /// </summary>
+        [NotNull]
+        public ImmutableList<Phi> Phis { get; }
+
+        /// <summary>
         /// Gets the index of the succeeding basic block.
         /// This may be -1 if this basic block ends in a return.
         /// If this basic block ends in a branch, <see cref="AlternativeSuccessor"/> may be used instead.
@@ -27,11 +33,22 @@ namespace Cle.SemanticAnalysis.IR
         /// </summary>
         public int AlternativeSuccessor { get; }
 
-        public BasicBlock(ImmutableList<Instruction> instructions, int defaultSuccessor, int alternativeSuccessor)
+        /// <summary>
+        /// Gets the predecessors of this basic block in an arbitrary order.
+        /// </summary>
+        [NotNull]
+        public ImmutableList<int> Predecessors { get; }
+
+        public BasicBlock([NotNull] ImmutableList<Instruction> instructions,
+            [NotNull] ImmutableList<Phi> phis,
+            int defaultSuccessor, int alternativeSuccessor,
+            [NotNull] ImmutableList<int> predecessors)
         {
             Instructions = instructions;
+            Phis = phis;
             DefaultSuccessor = defaultSuccessor;
             AlternativeSuccessor = alternativeSuccessor;
+            Predecessors = predecessors;
         }
         
         // TODO: Consider implementing equality comparisons (complication: ImmutableList<T> does not override Equals)

--- a/src/Cle.SemanticAnalysis/IR/BasicBlockBuilder.cs
+++ b/src/Cle.SemanticAnalysis/IR/BasicBlockBuilder.cs
@@ -14,6 +14,9 @@ namespace Cle.SemanticAnalysis.IR
         [NotNull]
         internal ImmutableList<Instruction>.Builder Instructions { get; } = ImmutableList<Instruction>.Empty.ToBuilder();
 
+        [NotNull]
+        internal ImmutableList<Phi>.Builder Phis { get; } = ImmutableList<Phi>.Empty.ToBuilder();
+
         /// <summary>
         /// Gets the index of this basic block.
         /// </summary>
@@ -82,6 +85,16 @@ namespace Cle.SemanticAnalysis.IR
         }
 
         /// <summary>
+        /// Adds a Phi node with the specified destination local index and source local indices.
+        /// </summary>
+        /// <param name="destination">The local that will receive the merged value from the Phi.</param>
+        /// <param name="operands">The operand locals to the Phi.</param>
+        public void AddPhi(int destination, [NotNull] ImmutableList<int> operands)
+        {
+            Phis.Add(new Phi(destination, operands));
+        }
+
+        /// <summary>
         /// Creates a new basic block builder and sets <see cref="DefaultSuccessor"/> to point to the new basic block.
         /// This method may not be called if the successor is already set.
         /// If this block has defined exit behavior, this only creates a builder and does not set the successor.
@@ -135,6 +148,24 @@ namespace Cle.SemanticAnalysis.IR
                 return;
 
             DefaultSuccessor = index;
+        }
+
+        /// <summary>
+        /// Sets the alternative successor.
+        /// Use <see cref="CreateBranch"/> instead unless you need to override the target block.
+        /// 
+        /// This method may not be called if the alternative successor is already set.
+        /// If the block already has defined exit behavior, this call does nothing.
+        /// </summary>
+        /// <param name="index">The basic block index. This is only checked when the basic block graph is built.</param>
+        public void SetAlternativeSuccessor(int index)
+        {
+            if (AlternativeSuccessor != -1)
+                throw new InvalidOperationException("The alternative successor is already set.");
+            if (HasDefinedExitBehavior)
+                return;
+
+            AlternativeSuccessor = index;
         }
     }
 }

--- a/src/Cle.SemanticAnalysis/IR/BasicBlockBuilder.cs
+++ b/src/Cle.SemanticAnalysis/IR/BasicBlockBuilder.cs
@@ -73,7 +73,7 @@ namespace Cle.SemanticAnalysis.IR
         /// Appends an instruction with the given parameters.
         /// If this block already has a defined exit, does nothing.
         /// </summary>
-        public void AppendInstruction(Opcode opcode, int left, int right, int destination)
+        public void AppendInstruction(Opcode opcode, ulong left, ushort right, ushort destination)
         {
             if (HasDefinedExitBehavior)
                 return;
@@ -104,7 +104,7 @@ namespace Cle.SemanticAnalysis.IR
         /// This method may be called if a successor is set, but not if the block already ends in a return or a branch.
         /// </summary>
         /// <param name="conditionValueIndex">The value index of the branch condition.</param>
-        public BasicBlockBuilder CreateBranch(int conditionValueIndex)
+        public BasicBlockBuilder CreateBranch(ushort conditionValueIndex)
         {
             if (Instructions.Count > 0 && (Instructions[Instructions.Count - 1].Operation == Opcode.Return ||
                                            Instructions[Instructions.Count - 1].Operation == Opcode.BranchIf))

--- a/src/Cle.SemanticAnalysis/IR/CompiledMethod.cs
+++ b/src/Cle.SemanticAnalysis/IR/CompiledMethod.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Cle.Common.TypeSystem;
 using JetBrains.Annotations;
 
@@ -46,13 +47,17 @@ namespace Cle.SemanticAnalysis.IR
         }
 
         /// <summary>
-        /// Creates a new local value with the specified type and initial value, and returns its value index.
-        /// The type of <paramref name="initialValue"/> is not checked against <paramref name="type"/>.
+        /// Creates a new local value of the specified type and returns its value index.
         /// </summary>
-        public int AddLocal([NotNull] TypeDefinition type, ConstantValue initialValue)
+        public ushort AddLocal([NotNull] TypeDefinition type, LocalFlags flags)
         {
-            _values.Add(new LocalValue(type, initialValue));
-            return _values.Count - 1;
+            if (_values.Count == ushort.MaxValue)
+            {
+                throw new IndexOutOfRangeException("Out of local indices");
+            }
+
+            _values.Add(new LocalValue(type, flags));
+            return (ushort)(_values.Count - 1);
         }
 
         /// <summary>
@@ -61,10 +66,10 @@ namespace Cle.SemanticAnalysis.IR
         /// <param name="calleeIndex">The body index of the called method.</param>
         /// <param name="parameterLocals">Local indices for the parameters.</param>
         /// <param name="calleeName">The full name of the called method, used for debugging.</param>
-        public int AddCallInfo(int calleeIndex, [NotNull] int[] parameterLocals, [NotNull] string calleeName)
+        public uint AddCallInfo(int calleeIndex, [NotNull] int[] parameterLocals, [NotNull] string calleeName)
         {
             _callInfos.Add(new MethodCallInfo(calleeIndex, parameterLocals, calleeName));
-            return _callInfos.Count - 1;
+            return (uint)(_callInfos.Count - 1);
         }
     }
 }

--- a/src/Cle.SemanticAnalysis/IR/Instruction.cs
+++ b/src/Cle.SemanticAnalysis/IR/Instruction.cs
@@ -9,28 +9,28 @@ namespace Cle.SemanticAnalysis.IR
     public readonly struct Instruction : IEquatable<Instruction>
     {
         /// <summary>
-        /// The operation code.
-        /// </summary>
-        public readonly Opcode Operation;
-
-        /// <summary>
         /// The first parameter to the operation.
         /// The interpretation of this field depends on the operation.
         /// </summary>
-        public readonly int Left;
+        public readonly ulong Left;
 
         /// <summary>
         /// The second parameter to the operation.
         /// The interpretation of this field depends on the operation.
         /// </summary>
-        public readonly int Right;
+        public readonly ushort Right;
 
         /// <summary>
         /// The destination local index of the operation.
         /// </summary>
-        public readonly int Destination;
+        public readonly ushort Destination;
 
-        public Instruction(Opcode operation, int left, int right, int destination)
+        /// <summary>
+        /// The operation code.
+        /// </summary>
+        public readonly Opcode Operation;
+
+        public Instruction(Opcode operation, ulong left, ushort right, ushort destination)
         {
             Operation = operation;
             Left = left;
@@ -83,6 +83,11 @@ namespace Cle.SemanticAnalysis.IR
         /// The source and destination operands are ignored.
         /// </summary>
         Nop,
+        /// <summary>
+        /// Loads the constant stored in the left operand to the local indexed by destination.
+        /// The constant bits are interpreted according to the local type.
+        /// </summary>
+        Load,
         /// <summary>
         /// Exit the method and return the value indexed by the left operand.
         /// </summary>

--- a/src/Cle.SemanticAnalysis/IR/LocalFlags.cs
+++ b/src/Cle.SemanticAnalysis/IR/LocalFlags.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Cle.SemanticAnalysis.IR
+{
+    /// <summary>
+    /// Flags for local values.
+    /// Not all flags are set by <see cref="MethodCompiler"/>.
+    /// </summary>
+    [Flags]
+    public enum LocalFlags
+    {
+        None = 0,
+        /// <summary>
+        /// This local is a parameter and must not be optimized away.
+        /// </summary>
+        Parameter = 1,
+    }
+}

--- a/src/Cle.SemanticAnalysis/IR/LocalValue.cs
+++ b/src/Cle.SemanticAnalysis/IR/LocalValue.cs
@@ -13,14 +13,14 @@ namespace Cle.SemanticAnalysis.IR
         public TypeDefinition Type { get; }
 
         /// <summary>
-        /// Gets the initial value of this local.
+        /// Gets additional information about this local.
         /// </summary>
-        public ConstantValue InitialValue { get; }
+        public LocalFlags Flags { get; }
 
-        public LocalValue(TypeDefinition type, ConstantValue initialValue)
+        public LocalValue(TypeDefinition type, LocalFlags flags)
         {
             Type = type;
-            InitialValue = initialValue;
+            Flags = flags;
         }
     }
 }

--- a/src/Cle.SemanticAnalysis/IR/Phi.cs
+++ b/src/Cle.SemanticAnalysis/IR/Phi.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Immutable;
+using JetBrains.Annotations;
+
+namespace Cle.SemanticAnalysis.IR
+{
+    /// <summary>
+    /// A Phi node used in the SSA form IR.
+    /// </summary>
+    public class Phi
+    {
+        /// <summary>
+        /// Gets the destination local index.
+        /// </summary>
+        public int Destination { get; }
+
+        /// <summary>
+        /// Gets the operand local indices.
+        /// </summary>
+        [NotNull]
+        public ImmutableList<int> Operands { get; }
+
+        public Phi(int destination, [NotNull] ImmutableList<int> operands)
+        {
+            Destination = destination;
+            Operands = operands;
+        }
+    }
+}

--- a/src/Cle.SemanticAnalysis/MethodCompiler.cs
+++ b/src/Cle.SemanticAnalysis/MethodCompiler.cs
@@ -150,7 +150,7 @@ namespace Cle.SemanticAnalysis
             for (var i = 0; i < _declaration.ParameterTypes.Count; i++)
             {
                 var paramSyntax = _syntaxTree.Parameters[i];
-                var paramIndex = _methodInProgress.AddLocal(_declaration.ParameterTypes[i], ConstantValue.Void());
+                var paramIndex = _methodInProgress.AddLocal(_declaration.ParameterTypes[i], ConstantValue.Parameter());
 
                 if (!_variableMap.TryAddVariable(paramSyntax.Name, paramIndex))
                 {

--- a/src/Cle.SemanticAnalysis/MethodCompiler.cs
+++ b/src/Cle.SemanticAnalysis/MethodCompiler.cs
@@ -150,7 +150,7 @@ namespace Cle.SemanticAnalysis
             for (var i = 0; i < _declaration.ParameterTypes.Count; i++)
             {
                 var paramSyntax = _syntaxTree.Parameters[i];
-                var paramIndex = _methodInProgress.AddLocal(_declaration.ParameterTypes[i], ConstantValue.Parameter());
+                var paramIndex = _methodInProgress.AddLocal(_declaration.ParameterTypes[i], LocalFlags.Parameter);
 
                 if (!_variableMap.TryAddVariable(paramSyntax.Name, paramIndex))
                 {
@@ -177,7 +177,7 @@ namespace Cle.SemanticAnalysis
                 // Others should fail
                 if (_declaration.ReturnType.Equals(SimpleType.Void))
                 {
-                    var voidIndex = _methodInProgress.AddLocal(SimpleType.Void, ConstantValue.Void());
+                    var voidIndex = _methodInProgress.AddLocal(SimpleType.Void, LocalFlags.None);
                     finalBlockBuilder.AppendInstruction(Opcode.Return, voidIndex, 0, 0);
                 }
                 else
@@ -285,7 +285,7 @@ namespace Cle.SemanticAnalysis
                 return false;
 
             // Emit a copy operation
-            builder.AppendInstruction(Opcode.CopyValue, sourceIndex, 0, targetIndex);
+            builder.AppendInstruction(Opcode.CopyValue, (ushort)sourceIndex, 0, (ushort)targetIndex);
             return true;
         }
 
@@ -305,7 +305,7 @@ namespace Cle.SemanticAnalysis
             }
 
             // Compile the 'then' branch
-            var thenBuilder = builder.CreateBranch(conditionValue);
+            var thenBuilder = builder.CreateBranch((ushort)conditionValue);
             if (!TryCompileBlock(ifSyntax.ThenBlockSyntax, thenBuilder, out thenBuilder, out var thenReturns))
             {
                 return false;
@@ -376,7 +376,7 @@ namespace Cle.SemanticAnalysis
             // Then compile the body.
             // The return guarantee is not propagated up as we don't know whether the loop will ever be entered.
             // TODO: Recognizing compile-time constant condition
-            var bodyBuilder = conditionBuilder.CreateBranch(conditionValue);
+            var bodyBuilder = conditionBuilder.CreateBranch((ushort)conditionValue);
             if (!TryCompileBlock(whileSyntax.BodySyntax, bodyBuilder, out bodyBuilder, out var _))
             {
                 return false;
@@ -402,7 +402,7 @@ namespace Cle.SemanticAnalysis
                 // Void return: verify that the method really returns void, then add a void local to return
                 if (_declaration.ReturnType.Equals(SimpleType.Void))
                 {
-                    returnValueNumber = _methodInProgress.AddLocal(SimpleType.Void, ConstantValue.Void());
+                    returnValueNumber = _methodInProgress.AddLocal(SimpleType.Void, LocalFlags.None);
                 }
                 else
                 {
@@ -421,7 +421,7 @@ namespace Cle.SemanticAnalysis
             if (returnValueNumber == -1)
                 return false;
 
-            builder.AppendInstruction(Opcode.Return, returnValueNumber, 0, 0);
+            builder.AppendInstruction(Opcode.Return, (ushort)returnValueNumber, 0, 0);
             return true;
         }
 
@@ -452,8 +452,8 @@ namespace Cle.SemanticAnalysis
                 var source = localIndex;
 
                 // Don't bother figuring out a correct initial value, it won't be used anyways
-                localIndex = _methodInProgress.AddLocal(type, ConstantValue.Void());
-                builder.AppendInstruction(Opcode.CopyValue, source, 0, localIndex);
+                localIndex = _methodInProgress.AddLocal(type, LocalFlags.None);
+                builder.AppendInstruction(Opcode.CopyValue, (ushort)source, 0, (ushort)localIndex);
             }
 
             // Add it to the variable map (unless the name is already in use)

--- a/src/Cle.SemanticAnalysis/MethodDisassembler.cs
+++ b/src/Cle.SemanticAnalysis/MethodDisassembler.cs
@@ -44,6 +44,21 @@ namespace Cle.SemanticAnalysis
                 // Basic block header
                 outputBuilder.AppendLine("BB_" + blockIndex + ":");
 
+                // Phis
+                foreach (var phi in block.Phis)
+                {
+                    outputBuilder.Append(Indent + "PHI (");
+
+                    for (var i = 0; i < phi.Operands.Count; i++)
+                    {
+                        if (i > 0)
+                            outputBuilder.Append(", ");
+                        outputBuilder.Append("#" + phi.Operands[i]);
+                    }
+
+                    outputBuilder.AppendLine(") -> #" + phi.Destination);
+                }
+
                 // Instructions
                 foreach (var instruction in block.Instructions)
                 {

--- a/src/Cle.SemanticAnalysis/README.md
+++ b/src/Cle.SemanticAnalysis/README.md
@@ -5,11 +5,14 @@ It receives syntax trees and outputs intermediate code (IR) suitable for optimiz
 
 The compilation happens in two phases:
 1. All declarations are verified (`MethodCompiler.CompileDeclaration` for methods) and added to a central location (not in this assembly).
-2. Method bodies are compiled (`MethodCompiler.CompileBody`) in arbitrary order.
+2. Method bodies are compiled in arbitrary order.
+  - First, `MethodCompiler.CompileBody` transforms the syntax tree into IR. This IR is not in SSA form.
+  - Then, `SsaConverter.ConvertToSsa` transforms the IR into SSA IR. Since the IR types are immutable, this ends up recreating all the data structures, but is easier to debug than on-the-fly conversion.
 
 ## Main points of interest
 - `MethodCompiler` does the bulk of semantic analysis.
 - `ExpressionCompiler` does the part related to expressions.
+- `SsaConverter` implements the SSA conversion.
 - Various `BasicBlock[...]` types represent and construct the IR.
 - The output of phase 1 is `MethodDeclaration`, which contains type information only.
 - The output of phase 2 is `CompiledMethod`, which combines IR code with local values (variables, constants, temporaries).

--- a/src/Cle.SemanticAnalysis/SsaConverter.cs
+++ b/src/Cle.SemanticAnalysis/SsaConverter.cs
@@ -72,9 +72,7 @@ namespace Cle.SemanticAnalysis
                     WriteVariable(localIndex, 0, CreateValueNumber(local.Type, local.Flags));
                 }
             }
-
-            // TODO: Create block builders here because Phis may be created out of order
-
+            
             // Convert each basic block
             _blockGraphBuilder = new BasicBlockGraphBuilder();
             for (var blockIndex = 0; blockIndex < method.Body.BasicBlocks.Count; blockIndex++)
@@ -238,8 +236,14 @@ namespace Cle.SemanticAnalysis
             var operands = ImmutableList<int>.Empty.ToBuilder();
             foreach (var predecessor in block.Predecessors)
             {
-                // TODO: Skip duplicates
-                operands.Add(ReadVariable(variableIndex, predecessor));
+                // Skip duplicate operands
+                // This is O(N^2) but N should be small, unless the user creates a horrible if-elseif chain
+                // TODO: Remove the Phi altogether if it has only one operand
+                var operand = ReadVariable(variableIndex, predecessor);
+                if (!operands.Contains(operand))
+                {
+                    operands.Add(operand);
+                }
             }
 
             // Write the Phi

--- a/src/Cle.SemanticAnalysis/SsaConverter.cs
+++ b/src/Cle.SemanticAnalysis/SsaConverter.cs
@@ -1,0 +1,236 @@
+﻿using System;
+using System.Diagnostics;
+using Cle.Common.TypeSystem;
+using Cle.SemanticAnalysis.IR;
+using JetBrains.Annotations;
+
+namespace Cle.SemanticAnalysis
+{
+    /// <summary>
+    /// <para>
+    /// Provides a method for converting a <see cref="CompiledMethod"/> into Static Single Assignment form.
+    /// This is required phase before code generation, but currently separate
+    /// from <see cref="MethodCompiler"/> for easier debugging.
+    /// </para>
+    /// <para>
+    /// A single instance can be used for successive SSA conversions, with the benefit of reduced allocations.
+    /// </para>
+    /// </summary>
+    /// 
+    /// <remarks>
+    /// The algorithm used here is described by Braun et al. in "Simple and Efficient Construction
+    /// of Static Single Assignment Form", proceedings of CC 2013 (Springer). The implementation
+    /// tries to mirror the paper as closely as sensible.
+    ///
+    /// This algorithm could be used on the fly within <see cref="MethodCompiler"/>, but that is not done
+    /// (at least for now) to make the algorithms easier to test and debug.
+    /// </remarks>
+    public class SsaConverter
+    {
+        private CompiledMethod _originalMethod;
+        private CompiledMethod _newMethod;
+
+        // Indexed by [original variable index, basic block index], values are offset by 1 so that 0 == undefined
+        private int[][] _ssaValues;
+
+        /// <summary>
+        /// Returns a new <see cref="CompiledMethod"/> instance equivalent to the original
+        /// <paramref name="method"/> after SSA conversion.
+        /// </summary>
+        /// <param name="method">The non-SSA method to convert.</param>
+        [NotNull]
+        public CompiledMethod ConvertToSsa([NotNull] CompiledMethod method)
+        {
+            if (method.Body is null)
+                throw new ArgumentNullException(nameof(method), "Method must have body");
+
+            // Reset the per-conversion data structures
+            _originalMethod = method;
+            _newMethod = new CompiledMethod(_originalMethod.FullName);
+            _ssaValues = new int[method.Values.Count][];
+
+            // Create value numbers for parameters and other locals with initial value
+            for (var localIndex = 0; localIndex < method.Values.Count; localIndex++)
+            {
+                var local = method.Values[localIndex];
+                if (!local.InitialValue.Equals(ConstantValue.Void()))
+                {
+                    WriteVariable(localIndex, 0, CreateValueNumber(local.Type, local.InitialValue));
+                }
+            }
+            
+            // Convert each basic block
+            var blockGraphBuilder = new BasicBlockGraphBuilder();
+            if (method.Body.BasicBlocks.Count > 1)
+            {
+                throw new NotImplementedException("Multiple BBs");
+            }
+            ConvertBlock(0, blockGraphBuilder.GetNewBasicBlock());
+
+            // Return the converted method
+            _newMethod.Body = blockGraphBuilder.Build();
+            return _newMethod;
+        }
+
+        /// <summary>
+        /// Converts the specified basic block into SSA form.
+        /// </summary>
+        /// <param name="blockIndex">The basic block index.</param>
+        /// <param name="builder">The builder for the basic block.</param>
+        private void ConvertBlock(int blockIndex, [NotNull] BasicBlockBuilder builder)
+        {
+            Debug.Assert(_originalMethod.Body != null);
+            var block = _originalMethod.Body.BasicBlocks[blockIndex];
+            
+            // Unreachable blocks are easy to convert!
+            if (block is null)
+                return;
+
+            foreach (var inst in block.Instructions)
+            {
+                if (inst.Operation == Opcode.Call)
+                {
+                    throw new NotImplementedException("Calls");
+                }
+
+                // Get SSA values for the operands
+                var left = ReadVariable(inst.Left, blockIndex);
+                var right = HasRightOperand(inst.Operation) ? ReadVariable(inst.Right, blockIndex) : 0;
+
+                // CopyValue instructions now become simple SSA name updates, while others are still emitted
+                if (inst.Operation == Opcode.CopyValue)
+                {
+                    WriteVariable(inst.Destination, blockIndex, left);
+                }
+                else
+                {
+                    // If the instruction produces a new value, we need an SSA number for it
+                    var dest = 0;
+                    if (DoesWriteValue(inst.Operation))
+                    {
+                        dest = CreateValueNumber(_originalMethod.Values[inst.Destination].Type, ConstantValue.Void());
+                        WriteVariable(inst.Destination, blockIndex, dest);
+                    }
+
+                    builder.AppendInstruction(inst.Operation, left, right, dest);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns the SSA name for the given variable in the specified block.
+        /// </summary>
+        /// <param name="variableIndex">The original local variable index.</param>
+        /// <param name="block">The basic block index.</param>
+        private int ReadVariable(int variableIndex, int block)
+        {
+            // Value of 0 or completely unset means that the local is not written to in this block
+            var localResult = _ssaValues[variableIndex]?[block] ?? 0;
+
+            if (localResult > 0)
+            {
+                // We have a local value number
+                return localResult - 1;
+            }
+            else
+            {
+                throw new NotImplementedException("Global value numbers");
+            }
+        }
+
+        /// <summary>
+        /// Associates a new SSA name with the given variable in the specified block.
+        /// </summary>
+        /// <param name="variableIndex">The original local variable index.</param>
+        /// <param name="block">The basic block index.</param>
+        /// <param name="newValue">The associated SSA name.</param>
+        private void WriteVariable(int variableIndex, int block, int newValue)
+        {
+            // The values are stored in an on-demand created jagged array to save a bit of space
+            if (_ssaValues[variableIndex] is null)
+            {
+                Debug.Assert(_originalMethod.Body != null);
+                _ssaValues[variableIndex] = new int[_originalMethod.Body.BasicBlocks.Count];
+            }
+
+            // The values are offset by 1 to distinguish uninitialized values
+            _ssaValues[variableIndex][block] = newValue + 1;
+        }
+
+        /// <summary>
+        /// Creates a new local value with the given type and initial value, and returns its value number.
+        /// </summary>
+        private int CreateValueNumber(TypeDefinition type, ConstantValue initialValue)
+        {
+            return _newMethod.AddLocal(type, initialValue);
+        }
+
+        /// <summary>
+        /// Returns whether the specified operation uses a right operand.
+        /// </summary>
+        private bool HasRightOperand(Opcode opcode)
+        {
+            switch (opcode)
+            {
+                case Opcode.Nop:
+                case Opcode.Return:
+                case Opcode.BranchIf:
+                case Opcode.CopyValue:
+                case Opcode.ArithmeticNegate:
+                case Opcode.BitwiseNot:
+                case Opcode.Call:
+                    return false;
+                case Opcode.Add:
+                case Opcode.Subtract:
+                case Opcode.Multiply:
+                case Opcode.Divide:
+                case Opcode.Modulo:
+                case Opcode.BitwiseAnd:
+                case Opcode.BitwiseOr:
+                case Opcode.BitwiseXor:
+                case Opcode.ShiftLeft:
+                case Opcode.ShiftRight:
+                case Opcode.Less:
+                case Opcode.LessOrEqual:
+                case Opcode.Equal:
+                    return true;
+                default:
+                    throw new NotImplementedException("Unimplemented opcode for HasRightOperand");
+            }
+        }
+
+        /// <summary>
+        /// Returns whether the specified operation writes to its destination operand.
+        /// </summary>
+        private bool DoesWriteValue(Opcode opcode)
+        {
+            switch (opcode)
+            {
+                case Opcode.Nop:
+                case Opcode.Return:
+                case Opcode.BranchIf:
+                    return false;
+                case Opcode.CopyValue:
+                case Opcode.ArithmeticNegate:
+                case Opcode.BitwiseNot:
+                case Opcode.Call:
+                case Opcode.Add:
+                case Opcode.Subtract:
+                case Opcode.Multiply:
+                case Opcode.Divide:
+                case Opcode.Modulo:
+                case Opcode.BitwiseAnd:
+                case Opcode.BitwiseOr:
+                case Opcode.BitwiseXor:
+                case Opcode.ShiftLeft:
+                case Opcode.ShiftRight:
+                case Opcode.Less:
+                case Opcode.LessOrEqual:
+                case Opcode.Equal:
+                    return true;
+                default:
+                    throw new NotImplementedException("Unimplemented opcode for DoesWriteValue");
+            }
+        }
+    }
+}

--- a/test/Cle.Benchmarks/SemanticAnalysis/SsaConverterBenchmarks.cs
+++ b/test/Cle.Benchmarks/SemanticAnalysis/SsaConverterBenchmarks.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using Cle.Parser;
+using Cle.SemanticAnalysis;
+using Cle.SemanticAnalysis.IR;
+
+namespace Cle.Benchmarks.SemanticAnalysis
+{
+    public class SsaConverterBenchmarks
+    {
+        private readonly CompiledMethod _smallMethod;
+        private readonly CompiledMethod _largeMethod;
+
+        public SsaConverterBenchmarks()
+        {
+            _smallMethod = ParseAndCompileSingleMethod(SmallSource);
+            _largeMethod = ParseAndCompileSingleMethod(LargeSource);
+        }
+
+        [Benchmark]
+        public CompiledMethod ConvertSmallMethod() => new SsaConverter().ConvertToSsa(_smallMethod);
+
+        [Benchmark]
+        public int ConvertLargeAndSmallMethod()
+        {
+            // This test reuses the SsaConverter instance to exercise caching
+            var converter = new SsaConverter();
+            var large = converter.ConvertToSsa(_largeMethod);
+            var small = converter.ConvertToSsa(_smallMethod);
+
+            return large.Values.Count + small.Values.Count;
+        }
+
+        private const string SmallSource = @"
+namespace Bench;
+
+private int32 Max(int32 a, int32 b)
+{
+    int32 result = a;
+    if (a < b)
+    {
+        result = b;
+    }
+    return result;
+}";
+
+        private const string LargeSource = @"
+namespace Bench;
+
+private int32 CollatzOnCollatz(int32 n)
+{
+    // How many steps until the sequence reaches 1?
+    int32 steps = 0;
+    while (n != 1)
+    {
+        if (n % 2 == 0)
+        {
+            n = n / 2;
+        }
+        else
+        {
+            n = 3 * n + 1;
+        }
+        steps = steps + 1;
+    }
+    
+    // And now, how many steps until the sequence (steps, ...) reaches 1?
+    n = steps;
+    steps = 0;
+    while (n != 1)
+    {
+        if (n % 2 == 0)
+        {
+            n = n / 2;
+        }
+        else
+        {
+            n = 3 * n + 1;
+        }
+        steps = steps + 1;
+    }
+    
+    return steps;
+}";
+
+        private CompiledMethod ParseAndCompileSingleMethod(string source)
+        {
+            var sourceBytes = Encoding.UTF8.GetBytes(source);
+            var diagnostics = new BenchmarkDiagnosticsSink();
+
+            // Parse the source
+            const string sourceFilename = "test.cle";
+            var syntaxTree = SyntaxParser.Parse(sourceBytes.AsMemory(), sourceFilename, diagnostics);
+
+            if (syntaxTree is null || syntaxTree.Functions.Count != 1)
+            {
+                throw new InvalidOperationException("Expected a single method");
+            }
+
+            // Compile the declaration
+            var declarationProvider = new NullDeclarationProvider();
+            var declaration = MethodCompiler.CompileDeclaration(syntaxTree.Functions[0],
+                syntaxTree.Namespace, sourceFilename,
+                0, declarationProvider, diagnostics);
+
+            // Compile the method body
+            var result = new MethodCompiler(declarationProvider, diagnostics)
+                .CompileBody(syntaxTree.Functions[0], declaration, syntaxTree.Namespace, sourceFilename);
+            
+            if (diagnostics.DiagnosticCount > 0)
+            {
+                throw new InvalidOperationException("Expected no diagnostics");
+            }
+            return result;
+        }
+    }
+
+    internal class NullDeclarationProvider : IDeclarationProvider
+    {
+        public IReadOnlyList<MethodDeclaration> GetMethodDeclarations(string methodName,
+            IReadOnlyList<string> visibleNamespaces, string sourceFile)
+        {
+            return new MethodDeclaration[] { };
+        }
+    }
+}

--- a/test/Cle.SemanticAnalysis.UnitTests/CompiledMethodTests.cs
+++ b/test/Cle.SemanticAnalysis.UnitTests/CompiledMethodTests.cs
@@ -11,14 +11,14 @@ namespace Cle.SemanticAnalysis.UnitTests
         {
             var method = new CompiledMethod("Test::Method");
 
-            Assert.That(method.AddLocal(SimpleType.Int32, ConstantValue.SignedInteger(1)), Is.EqualTo(0));
-            Assert.That(method.AddLocal(SimpleType.Int32, ConstantValue.SignedInteger(-17)), Is.EqualTo(1));
+            Assert.That(method.AddLocal(SimpleType.Int32, LocalFlags.None), Is.EqualTo(0));
+            Assert.That(method.AddLocal(SimpleType.Int32, LocalFlags.Parameter), Is.EqualTo(1));
 
             Assert.That(method.Values, Has.Exactly(2).Items);
             Assert.That(method.Values[0].Type, Is.EqualTo(SimpleType.Int32));
-            Assert.That(method.Values[0].InitialValue.AsSignedInteger, Is.EqualTo(1));
+            Assert.That(method.Values[0].Flags, Is.EqualTo(LocalFlags.None));
             Assert.That(method.Values[1].Type, Is.EqualTo(SimpleType.Int32));
-            Assert.That(method.Values[1].InitialValue.AsSignedInteger, Is.EqualTo(-17));
+            Assert.That(method.Values[1].Flags, Is.EqualTo(LocalFlags.Parameter));
         }
 
         [Test]
@@ -26,14 +26,14 @@ namespace Cle.SemanticAnalysis.UnitTests
         {
             var method = new CompiledMethod("Test::Method");
 
-            Assert.That(method.AddLocal(SimpleType.Bool, ConstantValue.Bool(true)), Is.EqualTo(0));
-            Assert.That(method.AddLocal(SimpleType.Bool, ConstantValue.Bool(false)), Is.EqualTo(1));
+            Assert.That(method.AddLocal(SimpleType.Bool, LocalFlags.None), Is.EqualTo(0));
+            Assert.That(method.AddLocal(SimpleType.Bool, LocalFlags.Parameter), Is.EqualTo(1));
 
             Assert.That(method.Values, Has.Exactly(2).Items);
             Assert.That(method.Values[0].Type, Is.EqualTo(SimpleType.Bool));
-            Assert.That(method.Values[0].InitialValue.AsBool, Is.EqualTo(true));
+            Assert.That(method.Values[0].Flags, Is.EqualTo(LocalFlags.None));
             Assert.That(method.Values[1].Type, Is.EqualTo(SimpleType.Bool));
-            Assert.That(method.Values[1].InitialValue.AsBool, Is.EqualTo(false));
+            Assert.That(method.Values[1].Flags, Is.EqualTo(LocalFlags.Parameter));
         }
     }
 }

--- a/test/Cle.SemanticAnalysis.UnitTests/MethodAssembler.cs
+++ b/test/Cle.SemanticAnalysis.UnitTests/MethodAssembler.cs
@@ -1,0 +1,193 @@
+﻿using System;
+using Cle.Common.TypeSystem;
+using Cle.SemanticAnalysis.IR;
+using JetBrains.Annotations;
+using NUnit.Framework;
+
+namespace Cle.SemanticAnalysis.UnitTests
+{
+    /// <summary>
+    /// An UNRELIABLE intermediate representation assembler for TESTING ONLY.
+    /// </summary>
+    internal static class MethodAssembler
+    {
+        /// <summary>
+        /// Creates a <see cref="CompiledMethod"/> out of the given IR disassembly,
+        /// which must follow the <see cref="MethodDisassembler"/> output very closely.
+        /// </summary>
+        public static CompiledMethod Assemble([NotNull] string source, [NotNull] string fullName)
+        {
+            var method = new CompiledMethod(fullName);
+            var graphBuilder = new BasicBlockGraphBuilder();
+            BasicBlockBuilder currentBlockBuilder = null;
+            
+            var lines = source.Replace("\r\n", "\n").Split('\n');
+            foreach (var rawLine in lines)
+            {
+                var currentLine = rawLine.Trim();
+
+                if (currentLine.Length == 0)
+                {
+                    // Empty (or whitespace) line - skip
+                }
+                else if (currentLine.StartsWith("; #"))
+                {
+                    // A variable definition (hopefully) - add a local
+                    ParseLocal(currentLine, method);
+                }
+                else if (currentLine.StartsWith("BB_"))
+                {
+                    // Starting a new basic block
+                    // The line is of form "BB_nnn:" so we have to chop bits off both ends
+                    var blockIndex = int.Parse(currentLine.Substring(3, currentLine.Length - 4));
+                    
+                    // Blocks may be omitted in the disassembly, so we may need to create the missing ones too
+                    while (currentBlockBuilder == null || currentBlockBuilder.Index < blockIndex)
+                    {
+                        currentBlockBuilder = graphBuilder.GetNewBasicBlock();
+                    }
+                    Assert.That(blockIndex, Is.EqualTo(currentBlockBuilder.Index), "Blocks must be specified in order.");
+                }
+                else
+                {
+                    Assert.That(currentBlockBuilder, Is.Not.Null, "No basic block has been started.");
+
+                    ParseInstruction(currentLine, method, currentBlockBuilder);
+                }
+
+                // TODO: Default successor behavior (fallthrough, explicit)
+            }
+
+            method.Body = graphBuilder.Build();
+            return method;
+        }
+
+        private static void ParseLocal(string line, CompiledMethod method)
+        {
+            var lineParts = line.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+            // Get the local index by removing the preceding #, and validate it
+            var localIndex = int.Parse(lineParts[1].Substring(1));
+            Assert.That(localIndex, Is.EqualTo(method.Values.Count), "Local indices must be specified in order.");
+
+            // Get the type and initial value
+            var type = ResolveType(lineParts[2]);
+            var value = ResolveValue(lineParts[4]);
+
+            method.AddLocal(type, value);
+        }
+
+        private static void ParseInstruction(string line, CompiledMethod method, BasicBlockBuilder builder)
+        {
+            var lineParts = line.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            Assert.That(Enum.TryParse<Opcode>(lineParts[0], out var opcode), Is.True, $"Unknown opcode: {lineParts[0]}");
+
+            // TODO: The remaining opcodes
+            if (opcode == Opcode.Return)
+            {
+                // Remove leading # before parsing the value number
+                var sourceIndex = int.Parse(lineParts[1].Substring(1));
+
+                builder.AppendInstruction(Opcode.Return, sourceIndex, 0, 0);
+            }
+            else if (IsUnary(opcode))
+            {
+                var sourceIndex = int.Parse(lineParts[1].Substring(1));
+                var destIndex = int.Parse(lineParts[3].Substring(1));
+
+                builder.AppendInstruction(opcode, sourceIndex, 0, destIndex);
+            }
+            else if (IsBinary(opcode))
+            {
+                var leftIndex = int.Parse(lineParts[1].Substring(1));
+                var rightIndex = int.Parse(lineParts[3].Substring(1));
+                var destIndex = int.Parse(lineParts[5].Substring(1));
+
+                builder.AppendInstruction(opcode, leftIndex, rightIndex, destIndex);
+            }
+            else
+            {
+                throw new NotImplementedException($"Unimplemented opcode to assemble: {opcode}");
+            }
+        }
+
+        private static TypeDefinition ResolveType(string typeName)
+        {
+            switch (typeName)
+            {
+                case "bool":
+                    return SimpleType.Bool;
+                case "int32":
+                    return SimpleType.Int32;
+                case "void":
+                    return SimpleType.Void;
+                default:
+                    throw new NotImplementedException($"Unimplemented type to assemble: {typeName}");
+            }
+        }
+
+        private static ConstantValue ResolveValue(string valueString)
+        {
+            if (valueString == "void")
+            {
+                return ConstantValue.Void();
+            }
+            else if (valueString == "param")
+            {
+                return ConstantValue.Parameter();
+            }
+            else if (valueString == "false")
+            {
+                return ConstantValue.Bool(false);
+            }
+            else if (valueString == "true")
+            {
+                return ConstantValue.Bool(true);
+            }
+            else if (int.TryParse(valueString, out var intValue))
+            {
+                return ConstantValue.SignedInteger(intValue);
+            }
+            else
+            {
+                throw new NotImplementedException($"Unimplemented value to assemble: {valueString}");
+            }
+        }
+
+        private static bool IsUnary(Opcode opcode)
+        {
+            switch (opcode)
+            {
+                case Opcode.ArithmeticNegate:
+                case Opcode.BitwiseNot:
+                case Opcode.CopyValue:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        private static bool IsBinary(Opcode opcode)
+        {
+            switch (opcode)
+            {
+                case Opcode.Add:
+                case Opcode.Subtract:
+                case Opcode.Multiply:
+                case Opcode.Divide:
+                case Opcode.Modulo:
+                case Opcode.BitwiseAnd:
+                case Opcode.BitwiseOr:
+                case Opcode.BitwiseXor:
+                case Opcode.ShiftLeft:
+                case Opcode.ShiftRight:
+                case Opcode.Less:
+                case Opcode.LessOrEqual:
+                case Opcode.Equal:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+    }
+}

--- a/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/CallTests.cs
+++ b/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/CallTests.cs
@@ -22,9 +22,9 @@ private void VoidMethod() {}";
             Assert.That(compiledMethod, Is.Not.Null);
             
             AssertDisassembly(compiledMethod, @"
-; #0   void = void
-; #1   void = void
-; #2   void = void
+; #0   void
+; #1   void
+; #2   void
 BB_0:
     Call Test::Namespace::VoidMethod() -> #0
     Call Test::Namespace::VoidMethod() -> #1
@@ -47,11 +47,13 @@ private bool IsLarger(int32 left, int32 right) { return left > right; }";
             Assert.That(compiledMethod, Is.Not.Null);
             
             AssertDisassembly(compiledMethod, @"
-; #0   int32 = 1
-; #1   int32 = 2
-; #2   bool = void
-; #3   void = void
+; #0   int32
+; #1   int32
+; #2   bool
+; #3   void
 BB_0:
+    Load 1 -> #0
+    Load 2 -> #1
     Call Test::IsLarger(#0, #1) -> #2
     Return #3");
         }
@@ -72,10 +74,12 @@ private bool IsLarger(int32 left, int32 right) { return left > right; }";
             Assert.That(compiledMethod, Is.Not.Null);
             
             AssertDisassembly(compiledMethod, @"
-; #0   int32 = 1
-; #1   int32 = 2
-; #2   bool = void
+; #0   int32
+; #1   int32
+; #2   bool
 BB_0:
+    Load 1 -> #0
+    Load 2 -> #1
     Call Test::IsLarger(#0, #1) -> #2
     Return #2");
         }
@@ -96,11 +100,12 @@ private bool IsLarger(int32 left, int32 right) { return left > right; }";
             Assert.That(compiledMethod, Is.Not.Null);
             
             AssertDisassembly(compiledMethod, @"
-; #0   int32 = param
-; #1   int32 = 1
-; #2   int32 = void
-; #3   bool = void
+; #0   int32 param
+; #1   int32
+; #2   int32
+; #3   bool
 BB_0:
+    Load 1 -> #1
     Add #0 + #0 -> #2
     Call Test::IsLarger(#1, #2) -> #3
     Return #3");

--- a/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/CallTests.cs
+++ b/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/CallTests.cs
@@ -96,7 +96,7 @@ private bool IsLarger(int32 left, int32 right) { return left > right; }";
             Assert.That(compiledMethod, Is.Not.Null);
             
             AssertDisassembly(compiledMethod, @"
-; #0   int32 = void
+; #0   int32 = param
 ; #1   int32 = 1
 ; #2   int32 = void
 ; #3   bool = void

--- a/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/IfTests.cs
+++ b/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/IfTests.cs
@@ -22,17 +22,20 @@ public bool Contradiction() {
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
             AssertDisassembly(compiledMethod, @"
-; #0   bool = true
-; #1   bool = false
-; #2   bool = true
+; #0   bool
+; #1   bool
+; #2   bool
 BB_0:
+    Load true -> #0
     BranchIf #0 ==> BB_1
     ==> BB_2
 
 BB_1:
+    Load false -> #1
     Return #1
 
 BB_2:
+    Load true -> #2
     Return #2");
         }
 
@@ -52,17 +55,20 @@ public bool Tautology() {
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
             AssertDisassembly(compiledMethod, @"
-; #0   bool = true
-; #1   bool = true
-; #2   bool = false
+; #0   bool
+; #1   bool
+; #2   bool
 BB_0:
+    Load true -> #0
     BranchIf #0 ==> BB_1
     ==> BB_2
 
 BB_1:
+    Load true -> #1
     Return #1
 
 BB_2:
+    Load false -> #2
     Return #2");
         }
 
@@ -83,20 +89,24 @@ public bool Comparison() {
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
             AssertDisassembly(compiledMethod, @"
-; #0   int32 = 42
-; #1   int32 = 100
-; #2   bool = void
-; #3   bool = true
-; #4   bool = false
+; #0   int32
+; #1   int32
+; #2   bool
+; #3   bool
+; #4   bool
 BB_0:
+    Load 42 -> #0
+    Load 100 -> #1
     Less #0 < #1 -> #2
     BranchIf #2 ==> BB_1
     ==> BB_2
 
 BB_1:
+    Load true -> #3
     Return #3
 
 BB_2:
+    Load false -> #4
     Return #4");
         }
 
@@ -117,14 +127,17 @@ public int32 TheAnswer() {
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
             AssertDisassembly(compiledMethod, @"
-; #0   int32 = 42
-; #1   bool = false
-; #2   int32 = 1
+; #0   int32
+; #1   bool
+; #2   int32
 BB_0:
+    Load 42 -> #0
+    Load false -> #1
     BranchIf #1 ==> BB_1
     ==> BB_2
 
 BB_1:
+    Load 1 -> #2
     CopyValue #2 -> #0
 
 BB_2:
@@ -149,19 +162,23 @@ public int32 ComplexAnswer() {
             Assert.That(diagnostics.Diagnostics, Is.Empty);
 
             AssertDisassembly(compiledMethod, @"
-; #0   int32 = 0
-; #1   bool = true
-; #2   int32 = 42
-; #3   int32 = 41
+; #0   int32
+; #1   bool
+; #2   int32
+; #3   int32
 BB_0:
+    Load 0 -> #0
+    Load true -> #1
     BranchIf #1 ==> BB_1
     ==> BB_2
 
 BB_1:
+    Load 42 -> #2
     CopyValue #2 -> #0
     ==> BB_3
 
 BB_2:
+    Load 41 -> #3
     CopyValue #3 -> #0
 
 BB_3:
@@ -185,26 +202,31 @@ public int32 GetTheAnswer() {
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
             AssertDisassembly(compiledMethod, @"
-; #0   bool = true
-; #1   bool = false
-; #2   int32 = 0
-; #3   int32 = 42
-; #4   int32 = 41
+; #0   bool
+; #1   bool
+; #2   int32
+; #3   int32
+; #4   int32
 BB_0:
+    Load true -> #0
     BranchIf #0 ==> BB_1
     ==> BB_5
 
 BB_1:
+    Load false -> #1
     BranchIf #1 ==> BB_2
     ==> BB_3
 
 BB_2:
+    Load 0 -> #2
     Return #2
 
 BB_3:
+    Load 42 -> #3
     Return #3
 
 BB_5:
+    Load 41 -> #4
     Return #4");
         }
 
@@ -227,12 +249,13 @@ public int32 GetTheAnswer() {
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
             AssertDisassembly(compiledMethod, @"
-; #0   bool = false
-; #1   bool = false
-; #2   int32 = 0
-; #3   int32 = 42
-; #4   int32 = 41
+; #0   bool
+; #1   bool
+; #2   int32
+; #3   int32
+; #4   int32
 BB_0:
+    Load false -> #0
     BranchIf #0 ==> BB_1
     ==> BB_2
 
@@ -240,16 +263,20 @@ BB_1:
     ==> BB_6
 
 BB_2:
+    Load false -> #1
     BranchIf #1 ==> BB_3
     ==> BB_4
 
 BB_3:
+    Load 0 -> #2
     Return #2
 
 BB_4:
+    Load 42 -> #3
     Return #3
 
 BB_6:
+    Load 41 -> #4
     Return #4");
         }
 
@@ -273,26 +300,31 @@ public int32 TheAnswer() {
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
             AssertDisassembly(compiledMethod, @"
-; #0   bool = true
-; #1   int32 = 42
-; #2   bool = false
-; #3   int32 = 41
-; #4   int32 = 0
+; #0   bool
+; #1   int32
+; #2   bool
+; #3   int32
+; #4   int32
 BB_0:
+    Load true -> #0
     BranchIf #0 ==> BB_1
     ==> BB_2
 
 BB_1:
+    Load 42 -> #1
     Return #1
 
 BB_2:
+    Load false -> #2
     BranchIf #2 ==> BB_3
     ==> BB_4
 
 BB_3:
+    Load 41 -> #3
     Return #3
 
 BB_4:
+    Load 0 -> #4
     Return #4");
         }
 
@@ -318,29 +350,35 @@ public int32 TheAnswer() {
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
             AssertDisassembly(compiledMethod, @"
-; #0   int32 = 0
-; #1   bool = true
-; #2   int32 = 42
-; #3   bool = false
-; #4   int32 = 41
-; #5   int32 = 1
+; #0   int32
+; #1   bool
+; #2   int32
+; #3   bool
+; #4   int32
+; #5   int32
 BB_0:
+    Load 0 -> #0
+    Load true -> #1
     BranchIf #1 ==> BB_1
     ==> BB_2
 
 BB_1:
+    Load 42 -> #2
     CopyValue #2 -> #0
     ==> BB_5
 
 BB_2:
+    Load false -> #3
     BranchIf #3 ==> BB_3
     ==> BB_4
 
 BB_3:
+    Load 41 -> #4
     CopyValue #4 -> #0
     ==> BB_5
 
 BB_4:
+    Load 1 -> #5
     CopyValue #5 -> #0
 
 BB_5:
@@ -365,26 +403,31 @@ public int32 TheAnswer() {
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
             AssertDisassembly(compiledMethod, @"
-; #0   bool = true
-; #1   int32 = 42
-; #2   bool = false
-; #3   int32 = 41
-; #4   int32 = 0
+; #0   bool
+; #1   int32
+; #2   bool
+; #3   int32
+; #4   int32
 BB_0:
+    Load true -> #0
     BranchIf #0 ==> BB_1
     ==> BB_2
 
 BB_1:
+    Load 42 -> #1
     Return #1
 
 BB_2:
+    Load false -> #2
     BranchIf #2 ==> BB_3
     ==> BB_4
 
 BB_3:
+    Load 41 -> #3
     Return #3
 
 BB_4:
+    Load 0 -> #4
     Return #4");
         }
 

--- a/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/ReturnTests.cs
+++ b/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/ReturnTests.cs
@@ -16,8 +16,9 @@ public bool ReturnTrue() { return true; }";
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
             AssertDisassembly(compiledMethod, @"
-; #0   bool = true
+; #0   bool
 BB_0:
+    Load true -> #0
     Return #0");
         }
 
@@ -32,8 +33,9 @@ public int32 GetTheAnswer() { return 42; }";
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
             AssertDisassembly(compiledMethod, @"
-; #0   int32 = 42
+; #0   int32
 BB_0:
+    Load 42 -> #0
     Return #0");
         }
 
@@ -48,8 +50,9 @@ public int32 GetTheAnswer() { return 40 + 2; }";
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
             AssertDisassembly(compiledMethod, @"
-; #0   int32 = 42
+; #0   int32
 BB_0:
+    Load 42 -> #0
     Return #0");
         }
 
@@ -64,10 +67,12 @@ public int32 GetTheAnswer() { int32 almost = 40; return almost + 2; }";
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
             AssertDisassembly(compiledMethod, @"
-; #0   int32 = 40
-; #1   int32 = 2
-; #2   int32 = void
+; #0   int32
+; #1   int32
+; #2   int32
 BB_0:
+    Load 40 -> #0
+    Load 2 -> #1
     Add #0 + #1 -> #2
     Return #2");
         }
@@ -83,7 +88,7 @@ public void DoNothing() { return; }";
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
             AssertDisassembly(compiledMethod, @"
-; #0   void = void
+; #0   void
 BB_0:
     Return #0");
         }
@@ -99,7 +104,7 @@ public void DoNothing() { }";
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
             AssertDisassembly(compiledMethod, @"
-; #0   void = void
+; #0   void
 BB_0:
     Return #0");
         }
@@ -115,10 +120,11 @@ public void DoNothing() { if (true) { return; } }";
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
             AssertDisassembly(compiledMethod, @"
-; #0   bool = true
-; #1   void = void
-; #2   void = void
+; #0   bool
+; #1   void
+; #2   void
 BB_0:
+    Load true -> #0
     BranchIf #0 ==> BB_1
     ==> BB_2
 

--- a/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/VariableTests.cs
+++ b/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/VariableTests.cs
@@ -262,8 +262,8 @@ public int32 Params(int32 first, bool second) {
             Assert.That(compiledMethod, Is.Not.Null);
 
             AssertDisassembly(compiledMethod, @"
-; #0   int32 = void
-; #1   bool = void
+; #0   int32 = param
+; #1   bool = param
 ; #2   int32 = 3
 BB_0:
     Return #0");

--- a/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/VariableTests.cs
+++ b/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/VariableTests.cs
@@ -20,9 +20,10 @@ public void DoNothing() {
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
             AssertDisassembly(compiledMethod, @"
-; #0   int32 = 7
-; #1   void = void
+; #0   int32
+; #1   void
 BB_0:
+    Load 7 -> #0
     CopyValue #0 -> #0
     Return #1");
         }
@@ -42,10 +43,12 @@ public void DoNothing() {
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
             AssertDisassembly(compiledMethod, @"
-; #0   int32 = 7
-; #1   int32 = 8
-; #2   void = void
+; #0   int32
+; #1   int32
+; #2   void
 BB_0:
+    Load 7 -> #0
+    Load 8 -> #1
     CopyValue #1 -> #0
     Return #2");
         }
@@ -66,10 +69,11 @@ public void DoNothing() {
             
             // void will be used for the initial value
             AssertDisassembly(compiledMethod, @"
-; #0   int32 = 7
-; #1   int32 = void
-; #2   void = void
+; #0   int32
+; #1   int32
+; #2   void
 BB_0:
+    Load 7 -> #0
     CopyValue #0 -> #1
     Return #2");
         }
@@ -214,10 +218,12 @@ public void NameAppearsTwice() {
             Assert.That(diagnostics.Diagnostics, Is.Empty);
 
             AssertDisassembly(compiledMethod, @"
-; #0   int32 = 7
-; #1   int32 = 8
-; #2   void = void
+; #0   int32
+; #1   int32
+; #2   void
 BB_0:
+    Load 7 -> #0
+    Load 8 -> #1
     Return #2");
         }
 
@@ -241,10 +247,12 @@ public void NameAppearsTwice() {
             Assert.That(diagnostics.Diagnostics, Is.Empty);
 
             AssertDisassembly(compiledMethod, @"
-; #0   int32 = 7
-; #1   int32 = 8
-; #2   void = void
+; #0   int32
+; #1   int32
+; #2   void
 BB_0:
+    Load 7 -> #0
+    Load 8 -> #1
     Return #2");
         }
 
@@ -262,10 +270,11 @@ public int32 Params(int32 first, bool second) {
             Assert.That(compiledMethod, Is.Not.Null);
 
             AssertDisassembly(compiledMethod, @"
-; #0   int32 = param
-; #1   bool = param
-; #2   int32 = 3
+; #0   int32 param
+; #1   bool param
+; #2   int32
 BB_0:
+    Load 3 -> #2
     Return #0");
         }
 

--- a/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/WhileTests.cs
+++ b/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/WhileTests.cs
@@ -20,11 +20,12 @@ public bool Stupid() {
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
             AssertDisassembly(compiledMethod, @"
-; #0   bool = true
-; #1   bool = false
+; #0   bool
+; #1   bool
 BB_0:
 
 BB_1:
+    Load true -> #0
     BranchIf #0 ==> BB_2
     ==> BB_3
 
@@ -32,6 +33,7 @@ BB_2:
     ==> BB_1
 
 BB_3:
+    Load false -> #1
     Return #1");
         }
 
@@ -53,13 +55,15 @@ public bool Stupid() {
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
             AssertDisassembly(compiledMethod, @"
-; #0   bool = false
-; #1   bool = void
-; #2   bool = false
+; #0   bool
+; #1   bool
+; #2   bool
 BB_0:
+    Load false -> #0
     CopyValue #0 -> #1
 
 BB_1:
+    Load false -> #2
     BranchIf #2 ==> BB_2
     ==> BB_5
 

--- a/test/Cle.SemanticAnalysis.UnitTests/MethodDisassemblerTests.cs
+++ b/test/Cle.SemanticAnalysis.UnitTests/MethodDisassemblerTests.cs
@@ -13,11 +13,11 @@ namespace Cle.SemanticAnalysis.UnitTests
             var graphBuilder = new BasicBlockGraphBuilder();
             graphBuilder.GetInitialBlockBuilder().AppendInstruction(Opcode.Return, 0, 0, 0);
             var method = new CompiledMethod("Test::Method") { Body = graphBuilder.Build() };
-            method.AddLocal(SimpleType.Int32, ConstantValue.SignedInteger(17));
-            method.AddLocal(SimpleType.Bool, ConstantValue.Bool(true));
+            method.AddLocal(SimpleType.Int32, LocalFlags.None);
+            method.AddLocal(SimpleType.Bool, LocalFlags.Parameter);
 
-            const string expected = "; #0   int32 = 17\n" +
-                                    "; #1   bool = true\n" +
+            const string expected = "; #0   int32\n" +
+                                    "; #1   bool param\n" +
                                     "BB_0:\n" +
                                     "    Return #0\n\n";
 
@@ -66,6 +66,8 @@ namespace Cle.SemanticAnalysis.UnitTests
 
             var graphBuilder = new BasicBlockGraphBuilder();
             var blockBuilder = graphBuilder.GetInitialBlockBuilder();
+            blockBuilder.AppendInstruction(Opcode.Load, unchecked((ulong)-17), 0, 0);
+            blockBuilder.AppendInstruction(Opcode.Load, 1, 0, 1);
             blockBuilder.AppendInstruction(Opcode.CopyValue, 1, 0, 2);
             blockBuilder.AppendInstruction(Opcode.Add, 1, 0, 2);
             blockBuilder.AppendInstruction(Opcode.Subtract, 1, 0, 2);
@@ -84,8 +86,12 @@ namespace Cle.SemanticAnalysis.UnitTests
             blockBuilder.AppendInstruction(Opcode.Equal, 1, 0, 2);
             blockBuilder.AppendInstruction(Opcode.Return, 2, 0, 0);
             var method = new CompiledMethod("Test::Method") { Body = graphBuilder.Build() };
+            method.AddLocal(SimpleType.Int32, LocalFlags.None);
+            method.AddLocal(SimpleType.Bool, LocalFlags.None);
 
             const string expected = "BB_0:\n" +
+                                    "    Load -17 -> #0\n" +
+                                    "    Load true -> #1\n" +
                                     "    CopyValue #1 -> #2\n" +
                                     "    Add #1 + #0 -> #2\n" +
                                     "    Subtract #1 - #0 -> #2\n" +

--- a/test/Cle.SemanticAnalysis.UnitTests/MethodDisassemblerTests.cs
+++ b/test/Cle.SemanticAnalysis.UnitTests/MethodDisassemblerTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Text;
 using Cle.Common.TypeSystem;
 using Cle.SemanticAnalysis.IR;
@@ -52,6 +53,26 @@ namespace Cle.SemanticAnalysis.UnitTests
 
             const string expected = "BB_0:\n" +
                                     "    Call Test::Callee(#3, #6, #9, #12) -> #1\n" +
+                                    "    Return #2\n\n";
+
+            var builder = new StringBuilder();
+            MethodDisassembler.DisassembleBody(method, builder);
+            Assert.That(builder.ToString().Replace("\r\n", "\n"), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void DisassembleBody_single_basic_block_with_phis()
+        {
+            var graphBuilder = new BasicBlockGraphBuilder();
+            var blockBuilder = graphBuilder.GetInitialBlockBuilder();
+            blockBuilder.AddPhi(7, ImmutableList<int>.Empty.Add(1));
+            blockBuilder.AddPhi(12, ImmutableList<int>.Empty.AddRange(new[] { 8, 6, 4 }));
+            blockBuilder.AppendInstruction(Opcode.Return, 2, 0, 0);
+            var method = new CompiledMethod("Test::Method") { Body = graphBuilder.Build() };
+
+            const string expected = "BB_0:\n" +
+                                    "    PHI (#1) -> #7\n" +
+                                    "    PHI (#8, #6, #4) -> #12\n" +
                                     "    Return #2\n\n";
 
             var builder = new StringBuilder();

--- a/test/Cle.SemanticAnalysis.UnitTests/SsaConverterTests.cs
+++ b/test/Cle.SemanticAnalysis.UnitTests/SsaConverterTests.cs
@@ -97,6 +97,285 @@ BB_0:
             AssertDisassembly(result, expected);
         }
 
+        [Test]
+        public void Successive_basic_blocks()
+        {
+            const string source = @"
+; #0   int32 param
+BB_0:
+    Multiply #0 * #0 -> #0
+
+BB_1:
+    Add #0 + #0 -> #0
+    Return #0
+";
+            var original = MethodAssembler.Assemble(source, "Test::Method");
+            var result = new SsaConverter().ConvertToSsa(original);
+
+            const string expected = @"
+; #0   int32 param
+; #1   int32
+; #2   int32
+BB_0:
+    Multiply #0 * #0 -> #1
+
+BB_1:
+    Add #1 + #1 -> #2
+    Return #2
+";
+            AssertDisassembly(result, expected);
+        }
+
+        [Test]
+        public void Successive_basic_blocks_with_gap_in_between()
+        {
+            const string source = @"
+; #0   int32 param
+BB_0:
+    Multiply #0 * #0 -> #0
+    ==> BB_2
+
+BB_2:
+    Add #0 + #0 -> #0
+    Return #0
+";
+            var original = MethodAssembler.Assemble(source, "Test::Method");
+            var result = new SsaConverter().ConvertToSsa(original);
+
+            const string expected = @"
+; #0   int32 param
+; #1   int32
+; #2   int32
+BB_0:
+    Multiply #0 * #0 -> #1
+    ==> BB_2
+
+BB_2:
+    Add #1 + #1 -> #2
+    Return #2
+";
+            AssertDisassembly(result, expected);
+        }
+
+        [Test]
+        public void Branch_that_does_not_merge_back()
+        {
+            const string source = @"
+; #0   int32 param
+; #1   bool param
+; #2   int32
+BB_0:
+    BranchIf #1 ==> BB_1
+    ==> BB_2
+
+BB_1:
+    Multiply #0 * #0 -> #2
+    Return #2
+
+BB_2:
+    Return #0
+";
+            var original = MethodAssembler.Assemble(source, "Test::Method");
+            var result = new SsaConverter().ConvertToSsa(original);
+            
+            // No change expected
+            AssertDisassembly(result, source);
+        }
+
+        [Test]
+        public void Branch_that_merges_back_and_produces_phi()
+        {
+            // int32 f(int32 value, bool square)
+            // {
+            //     int32 result = value;
+            //     if (square) { result = result * result; }
+            //     return result;
+            // }
+            const string source = @"
+; #0   int32 param
+; #1   bool param
+; #2   int32
+; #3   int32
+BB_0:
+    CopyValue #0 -> #2
+    BranchIf #1 ==> BB_1
+    ==> BB_2
+
+BB_1:
+    Multiply #2 * #2 -> #3
+    CopyValue #3 -> #2
+
+BB_2:
+    Return #2
+";
+            var original = MethodAssembler.Assemble(source, "Test::Method");
+            var result = new SsaConverter().ConvertToSsa(original);
+
+            const string expected = @"
+; #0   int32 param
+; #1   bool param
+; #2   int32
+; #3   int32
+BB_0:
+    BranchIf #1 ==> BB_1
+    ==> BB_2
+
+BB_1:
+    Multiply #0 * #0 -> #2
+
+BB_2:
+    PHI (#0, #2) -> #3
+    Return #3
+";
+            AssertDisassembly(result, expected);
+        }
+
+        [Test]
+        public void Double_branch_that_merges_back_and_produces_phis_in_two_blocks()
+        {
+            // int32 f(int32 value, bool square, bool twice)
+            // {
+            //     int32 result = value;
+            //     if (square) {
+            //         result = result * result;
+            //         if (twice) { result = result * result; }
+            //     }
+            //     return result;
+            // }
+            const string source = @"
+; #0   int32 param
+; #1   bool param
+; #2   bool param
+; #3   int32
+; #4   int32
+; #5   int32
+BB_0:
+    CopyValue #0 -> #3
+    BranchIf #1 ==> BB_1
+    ==> BB_4
+
+BB_1:
+    Multiply #3 * #3 -> #4
+    CopyValue #4 -> #3
+    BranchIf #2 ==> BB_2
+    ==> BB_3
+
+BB_2:
+    Multiply #3 * #3 -> #5
+    CopyValue #5 -> #3
+
+BB_3:
+
+BB_4:
+    Return #3
+";
+            var original = MethodAssembler.Assemble(source, "Test::Method");
+            var result = new SsaConverter().ConvertToSsa(original);
+
+            const string expected = @"
+; #0   int32 param
+; #1   bool param
+; #2   bool param
+; #3   int32
+; #4   int32
+; #5   int32
+; #6   int32
+BB_0:
+    BranchIf #1 ==> BB_1
+    ==> BB_4
+
+BB_1:
+    Multiply #0 * #0 -> #3
+    BranchIf #2 ==> BB_2
+    ==> BB_3
+
+BB_2:
+    Multiply #3 * #3 -> #4
+
+BB_3:
+    PHI (#3, #4) -> #6
+
+BB_4:
+    PHI (#0, #6) -> #5
+    Return #5
+";
+            AssertDisassembly(result, expected);
+        }
+
+        [Test]
+        public void Branch_that_merges_back_three_way_and_produces_one_phi()
+        {
+            // int32 f(bool a, bool b)
+            // {
+            //     int32 result = 0;
+            //     if (a & b) { result = 3; }
+            //     else if (a) { result = 2; }
+            //     return result;
+            // }
+            const string source = @"
+; #0   bool param
+; #1   bool param
+; #2   int32
+; #3   bool
+; #4   int32
+; #5   int32
+BB_0:
+    Load 0 -> #2
+    BitwiseAnd #0 & #1 -> #3
+    BranchIf #3 ==> BB_1
+    ==> BB_2
+
+BB_1:
+    Load 3 -> #4
+    CopyValue #4 -> #2
+    ==> BB_4
+
+BB_2:
+    BranchIf #0 ==> BB_3
+    ==> BB_4
+
+BB_3:
+    Load 2 -> #5
+    CopyValue #5 -> #2
+
+BB_4:
+    Return #2
+";
+            var original = MethodAssembler.Assemble(source, "Test::Method");
+            var result = new SsaConverter().ConvertToSsa(original);
+
+            const string expected = @"
+; #0   bool param
+; #1   bool param
+; #2   int32
+; #3   bool
+; #4   int32
+; #5   int32
+; #6   int32
+BB_0:
+    Load 0 -> #2
+    BitwiseAnd #0 & #1 -> #3
+    BranchIf #3 ==> BB_1
+    ==> BB_2
+
+BB_1:
+    Load 3 -> #4
+    ==> BB_4
+
+BB_2:
+    BranchIf #0 ==> BB_3
+    ==> BB_4
+
+BB_3:
+    Load 2 -> #5
+
+BB_4:
+    PHI (#2, #5, #4) -> #6
+    Return #6
+";
+            AssertDisassembly(result, expected);
+        }
+
         private void AssertDisassembly(CompiledMethod compiledMethod, string expected)
         {
             var builder = new StringBuilder();

--- a/test/Cle.SemanticAnalysis.UnitTests/SsaConverterTests.cs
+++ b/test/Cle.SemanticAnalysis.UnitTests/SsaConverterTests.cs
@@ -14,11 +14,14 @@ namespace Cle.SemanticAnalysis.UnitTests
             // a = 2;
             // return a;
             const string source = @"
-; #0   int32 = 0
-; #1   int32 = 1
-; #2   int32 = 2
+; #0   int32
+; #1   int32
+; #2   int32
 BB_0:
+    Load 0 -> #0
+    Load 1 -> #1
     CopyValue #1 -> #0
+    Load 2 -> #2
     CopyValue #2 -> #0
     Return #0
 ";
@@ -26,10 +29,13 @@ BB_0:
             var result = new SsaConverter().ConvertToSsa(original);
 
             const string expected = @"
-; #0   int32 = 0
-; #1   int32 = 1
-; #2   int32 = 2
+; #0   int32
+; #1   int32
+; #2   int32
 BB_0:
+    Load 0 -> #0
+    Load 1 -> #1
+    Load 2 -> #2
     Return #2
 ";
             AssertDisassembly(result, expected);
@@ -44,10 +50,10 @@ BB_0:
             //     return c - a;
             // }
             const string source = @"
-; #0   int32 = param
-; #1   int32 = param
-; #2   int32 = void
-; #3   int32 = void
+; #0   int32 param
+; #1   int32 param
+; #2   int32
+; #3   int32
 BB_0:
     Add #0 + #1 -> #2
     Subtract #2 - #0 -> #3
@@ -70,7 +76,7 @@ BB_0:
             //     return a;
             // }
             const string source = @"
-; #0   int32 = param
+; #0   int32 param
 BB_0:
     Multiply #0 * #0 -> #0
     Add #0 + #0 -> #0
@@ -80,9 +86,9 @@ BB_0:
             var result = new SsaConverter().ConvertToSsa(original);
 
             const string expected = @"
-; #0   int32 = param
-; #1   int32 = void
-; #2   int32 = void
+; #0   int32 param
+; #1   int32
+; #2   int32
 BB_0:
     Multiply #0 * #0 -> #1
     Add #1 + #1 -> #2

--- a/test/Cle.SemanticAnalysis.UnitTests/SsaConverterTests.cs
+++ b/test/Cle.SemanticAnalysis.UnitTests/SsaConverterTests.cs
@@ -1,0 +1,103 @@
+using System.Text;
+using Cle.SemanticAnalysis.IR;
+using NUnit.Framework;
+
+namespace Cle.SemanticAnalysis.UnitTests
+{
+    public class SsaConverterTests
+    {
+        [Test]
+        public void Single_basic_block_with_same_variable_assigned_thrice()
+        {
+            // int32 a = 0;
+            // a = 1;
+            // a = 2;
+            // return a;
+            const string source = @"
+; #0   int32 = 0
+; #1   int32 = 1
+; #2   int32 = 2
+BB_0:
+    CopyValue #1 -> #0
+    CopyValue #2 -> #0
+    Return #0
+";
+            var original = MethodAssembler.Assemble(source, "Test::Method");
+            var result = new SsaConverter().ConvertToSsa(original);
+
+            const string expected = @"
+; #0   int32 = 0
+; #1   int32 = 1
+; #2   int32 = 2
+BB_0:
+    Return #2
+";
+            AssertDisassembly(result, expected);
+        }
+
+        [Test]
+        public void Single_basic_block_with_already_ssa_arithmetic_on_parameters()
+        {
+            // int32 f(int32 a, int32 b)
+            // {
+            //     int32 c = a + b;
+            //     return c - a;
+            // }
+            const string source = @"
+; #0   int32 = param
+; #1   int32 = param
+; #2   int32 = void
+; #3   int32 = void
+BB_0:
+    Add #0 + #1 -> #2
+    Subtract #2 - #0 -> #3
+    Return #3
+";
+            var original = MethodAssembler.Assemble(source, "Test::Method");
+            var result = new SsaConverter().ConvertToSsa(original);
+            
+            // The source is already in SSA form, so no diff is expected
+            AssertDisassembly(result, source);
+        }
+
+        [Test]
+        public void Single_basic_block_with_reassignment_of_parameter()
+        {
+            // int32 TwiceParamSquared(int32 a)
+            // {
+            //     a = a * a;
+            //     a = a + a;
+            //     return a;
+            // }
+            const string source = @"
+; #0   int32 = param
+BB_0:
+    Multiply #0 * #0 -> #0
+    Add #0 + #0 -> #0
+    Return #0
+";
+            var original = MethodAssembler.Assemble(source, "Test::Method");
+            var result = new SsaConverter().ConvertToSsa(original);
+
+            const string expected = @"
+; #0   int32 = param
+; #1   int32 = void
+; #2   int32 = void
+BB_0:
+    Multiply #0 * #0 -> #1
+    Add #1 + #1 -> #2
+    Return #2
+";
+            AssertDisassembly(result, expected);
+        }
+
+        private void AssertDisassembly(CompiledMethod compiledMethod, string expected)
+        {
+            var builder = new StringBuilder();
+            MethodDisassembler.Disassemble(compiledMethod, builder);
+
+            Assert.That(builder.ToString().Trim().Replace("\r\n", "\n"),
+                Is.EqualTo(expected.Trim().Replace("\r\n", "\n")));
+        }
+    }
+}


### PR DESCRIPTION
Closes #5.

Implemented SSA conversion as a separate pass from `MethodCompiler`. The algorithm is also suitable for on-the-fly conversion; filing a follow-up issue for the future. For now, this version should be easier to debug, but later on the throughput can be improved by emitting SSA straight away.

This also includes a major change to how locals are initialized. It does not really make a huge difference, and could have been left as it was, but now there is only one way a local can be initialized. Constant lifetimes are now slightly more explicit (not really an issue, though), and e.g. future constant folding will benefit for the single way of setting locals.