### PR TITLE
Fix SSA crashing in void functions

### DIFF
--- a/src/Cle.SemanticAnalysis/SsaConverter.cs
+++ b/src/Cle.SemanticAnalysis/SsaConverter.cs
@@ -63,13 +63,24 @@ namespace Cle.SemanticAnalysis
             _incompletePhis = new List<(ushort, ushort)>[blockCount];
             _isSealed = new bool[blockCount];
 
-            // Create value numbers for parameters
+            // Create value numbers for parameters.
+            // Additionally, create a single value number that is used for all void returns.
+            // (There is no sense in initializing a void value, let alone having several!)
+            var voidIndex = -1;
             for (var localIndex = (ushort)0; localIndex < method.Values.Count; localIndex++)
             {
                 var local = method.Values[localIndex];
                 if (local.Flags.HasFlag(LocalFlags.Parameter))
                 {
                     WriteVariable(localIndex, 0, CreateValueNumber(local.Type, local.Flags));
+                }
+                else if (local.Type.Equals(SimpleType.Void))
+                {
+                    if (voidIndex < 0)
+                    {
+                        voidIndex = CreateValueNumber(SimpleType.Void, LocalFlags.None);
+                    }
+                    WriteVariable(localIndex, 0, (ushort)voidIndex);
                 }
             }
             

--- a/test/Cle.SemanticAnalysis.UnitTests/SsaConverterTests.cs
+++ b/test/Cle.SemanticAnalysis.UnitTests/SsaConverterTests.cs
@@ -750,6 +750,47 @@ BB_4:
             AssertDisassembly(result, expected);
         }
 
+        [Test]
+        public void Void_returns_use_shared_value()
+        {
+            // void F(bool p)
+            // {
+            //     if (p) { return; }
+            // }
+            const string source = @"
+; #0   bool param
+; #1   void
+; #2   void
+BB_0:
+    BranchIf #0 ==> BB_1
+    ==> BB_2
+
+BB_1:
+    Return #1
+
+BB_2:
+    Return #2
+";
+            var original = MethodAssembler.Assemble(source, "Test::Method");
+            var result = new SsaConverter().ConvertToSsa(original);
+
+            // The same (uninitialized) void value is used for both returns
+            const string expected = @"
+; #0   bool param
+; #1   void
+BB_0:
+    BranchIf #0 ==> BB_1
+    ==> BB_2
+
+BB_1:
+    Return #1
+
+BB_2:
+    Return #1
+";
+            AssertDisassembly(result, expected);
+        }
+
         private void AssertDisassembly(CompiledMethod compiledMethod, string expected)
         {
             var builder = new StringBuilder();


### PR DESCRIPTION
Part of #5.

`SsaConverter` asserted because `void` return values are never initialized. Added initialization and merging of void locals.

**Bug root cause:** Insufficient testing. Unit testing focused on testing the SSA algorithm and there is not yet an integration test suite.