### PR TITLE
Fix cmp codegen

### DIFF
--- a/src/Cle.CodeGeneration/WindowsX64CodeGenerator.cs
+++ b/src/Cle.CodeGeneration/WindowsX64CodeGenerator.cs
@@ -135,8 +135,13 @@ namespace Cle.CodeGeneration
                         EmitIntegerBinaryOp(BinaryOp.Subtract, in inst, method);
                         break;
                     case LowOp.Compare:
-                        emitter.EmitCmp(method.Locals[inst.Left].Location, method.Locals[inst.Right].Location);
+                    {
+                        // TODO: Can the left and right operands have different sizes?
+                        var operandSize = method.Locals[inst.Left].Type.SizeInBytes;
+
+                        emitter.EmitCmp(method.Locals[inst.Left].Location, method.Locals[inst.Right].Location, operandSize);
                         break;
+                    }
                     case LowOp.Test:
                     {
                         var srcDestLocation = method.Locals[inst.Left].Location;

--- a/src/Cle.CodeGeneration/X64Emitter.cs
+++ b/src/Cle.CodeGeneration/X64Emitter.cs
@@ -151,24 +151,24 @@ namespace Cle.CodeGeneration
         }
 
         /// <summary>
-        /// Emits a cmp instruction with the two operands.
-        /// The operands are considered to be full width.
+        /// Emits a cmp instruction with the two operands and specified operand width.
         /// </summary>
-        // TODO: Support specifying operand size
-        public void EmitCmp(StorageLocation<X64Register> left, StorageLocation<X64Register> right)
+        public void EmitCmp(StorageLocation<X64Register> left, StorageLocation<X64Register> right, int operandSize)
         {
+            if (operandSize != 4 && operandSize != 8)
+                throw new NotImplementedException("Other operand widths");
             if (!left.IsRegister || !right.IsRegister)
                 throw new NotImplementedException("Cmp on stack");
             if (left.Register >= X64Register.Xmm0 || right.Register >= X64Register.Xmm0)
                 throw new NotImplementedException("SIMD compare");
 
             // General-to-general register cmp
-            DisassembleRegReg("cmp", left.Register, right.Register, 8);
+            DisassembleRegReg("cmp", left.Register, right.Register, operandSize);
 
             var (encodedDest, needR) = GetRegisterEncoding(left.Register);
             var (encodedSrc, needB) = GetRegisterEncoding(right.Register);
 
-            EmitRexPrefixIfNeeded(true, needR, false, needB);
+            EmitRexPrefixIfNeeded(operandSize == 8, needR, false, needB);
             _outputStream.WriteByte(0x3B);
             EmitModRmForRegisterToRegister(encodedDest, encodedSrc);
         }

--- a/test/Cle.CodeGeneration.UnitTests/X64CodeGenerator/BranchTests.cs
+++ b/test/Cle.CodeGeneration.UnitTests/X64CodeGenerator/BranchTests.cs
@@ -41,7 +41,7 @@ BB_2:
 LB_0:
     mov eax, 2Ah
     mov ecx, 64h
-    cmp rax, rcx
+    cmp eax, ecx
     {expectedConditionalJump} LB_1
     jmp LB_2
 LB_1:
@@ -93,7 +93,7 @@ BB_2:
 LB_0:
     mov eax, 2Ah
     mov ecx, 64h
-    cmp rax, rcx
+    cmp eax, ecx
     {expectedConditionalJump} LB_1
     jmp LB_2
 LB_1:

--- a/test/Cle.CodeGeneration.UnitTests/X64CodeGenerator/VariableTests.cs
+++ b/test/Cle.CodeGeneration.UnitTests/X64CodeGenerator/VariableTests.cs
@@ -46,7 +46,7 @@ BB_0:
 LB_0:
     mov eax, 2Ah
     mov ecx, 64h
-    cmp rax, rcx
+    cmp eax, ecx
     {expectedLowOp} al
     movzx rax, al
     ret
@@ -79,7 +79,7 @@ BB_0:
 LB_0:
     mov eax, 2Ah
     mov ecx, 64h
-    cmp rax, rcx
+    cmp eax, ecx
     {expectedLowOp} al
     movzx rax, al
     ret

--- a/test/Cle.CodeGeneration.UnitTests/X64EmitterTests.cs
+++ b/test/Cle.CodeGeneration.UnitTests/X64EmitterTests.cs
@@ -205,22 +205,44 @@ namespace Cle.CodeGeneration.UnitTests
         }
 
         [Test]
-        public void EmitCmp_emits_compare_between_basic_registers()
+        public void EmitCmp_emits_32_bit_compare_between_basic_registers()
+        {
+            GetEmitter(out var stream, out var disassembly).EmitCmp(
+                new StorageLocation<X64Register>(X64Register.Rbx),
+                new StorageLocation<X64Register>(X64Register.Rsp), 4);
+
+            CollectionAssert.AreEqual(new byte[] { 0x3B, 0xDC }, stream.ToArray());
+            Assert.That(disassembly.ToString().Trim(), Is.EqualTo("cmp ebx, esp"));
+        }
+
+        [Test]
+        public void EmitCmp_emits_32_bit_compare_between_new_registers()
+        {
+            GetEmitter(out var stream, out var disassembly).EmitCmp(
+                new StorageLocation<X64Register>(X64Register.R10),
+                new StorageLocation<X64Register>(X64Register.R11), 4);
+
+            CollectionAssert.AreEqual(new byte[] { 0x45, 0x3B, 0xD3 }, stream.ToArray());
+            Assert.That(disassembly.ToString().Trim(), Is.EqualTo("cmp r10d, r11d"));
+        }
+
+        [Test]
+        public void EmitCmp_emits_64_bit_compare_between_basic_registers()
         {
             GetEmitter(out var stream, out var disassembly).EmitCmp(
                 new StorageLocation<X64Register>(X64Register.Rax),
-                new StorageLocation<X64Register>(X64Register.Rbx));
+                new StorageLocation<X64Register>(X64Register.Rbx), 8);
 
             CollectionAssert.AreEqual(new byte[] { 0x48, 0x3B, 0xC3 }, stream.ToArray());
             Assert.That(disassembly.ToString().Trim(), Is.EqualTo("cmp rax, rbx"));
         }
 
         [Test]
-        public void EmitCmp_emits_compare_between_new_registers()
+        public void EmitCmp_emits_64_bit_compare_between_new_registers()
         {
             GetEmitter(out var stream, out var disassembly).EmitCmp(
                 new StorageLocation<X64Register>(X64Register.R8),
-                new StorageLocation<X64Register>(X64Register.R15));
+                new StorageLocation<X64Register>(X64Register.R15), 8);
 
             CollectionAssert.AreEqual(new byte[] { 0x4D, 0x3B, 0xC7 }, stream.ToArray());
             Assert.That(disassembly.ToString().Trim(), Is.EqualTo("cmp r8, r15"));

--- a/test/Cle.IntegrationTests/CodeGenBringUpTests.cs
+++ b/test/Cle.IntegrationTests/CodeGenBringUpTests.cs
@@ -16,6 +16,7 @@ namespace Cle.IntegrationTests
         [TestCase("ReturnParameter", 100)]
         [TestCase("SimpleForwardPhi", 50)]
         [TestCase("SimpleWhileLoop", 45)]
+        [TestCase("SimpleWhileLoop2", 36)]
         public void CodeGenBringUp(string testCase, int expectedReturnCode)
         {
             new TestRunner(Path.Combine(BaseDirectory, testCase))

--- a/test/Cle.IntegrationTests/TestCases/CodeGenBringUp/SimpleWhileLoop2/SimpleWhileLoop2.cle
+++ b/test/Cle.IntegrationTests/TestCases/CodeGenBringUp/SimpleWhileLoop2/SimpleWhileLoop2.cle
@@ -1,0 +1,22 @@
+// As opposed to the SimpleWhileLoop test, the loop variable goes down by 2 each iteration.
+// This catches an issue with 64-bit compare used for 32-bit values.
+//
+// Expected return code: 36.
+// No console output expected.
+
+namespace SimpleWhileLoop2;
+
+[EntryPoint]
+public int32 Main()
+{
+    int32 i = 11; // Must be odd so that 0 is never reached
+    int32 sum = 0;
+    
+    while (i > 0)
+    {
+        sum = sum + i;
+        i = i - 2;
+    }
+    
+    return sum;
+}


### PR DESCRIPTION
The associated test case shows that -1 >= 0 when the operands are 64-bit, since 32-bit `sub` does not sign extend (as expected). A 32-bit comparison must be used in that case.

Contributes to #6. This was annoying enough to deserve its own PR.