### PR TITLE
Implement a proper LSRA algorithm

### DIFF
--- a/cle.sln
+++ b/cle.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28803.156
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{A14775F6-0FFF-449E-8160-D31C668A441A}"
 EndProject
@@ -21,19 +21,19 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cle.Compiler.UnitTests", "t
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cle.Benchmarks", "test\Cle.Benchmarks\Cle.Benchmarks.csproj", "{A150652B-4F9C-4BAA-9134-C6AF2A579E70}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cle.SemanticAnalysis", "src\Cle.SemanticAnalysis\Cle.SemanticAnalysis.csproj", "{2132E910-AA45-44D9-95FE-F4D3A0C1D0EE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cle.SemanticAnalysis", "src\Cle.SemanticAnalysis\Cle.SemanticAnalysis.csproj", "{2132E910-AA45-44D9-95FE-F4D3A0C1D0EE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cle.SemanticAnalysis.UnitTests", "test\Cle.SemanticAnalysis.UnitTests\Cle.SemanticAnalysis.UnitTests.csproj", "{DE0352C7-509B-4BAE-B9E2-5EA4343E788B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cle.SemanticAnalysis.UnitTests", "test\Cle.SemanticAnalysis.UnitTests\Cle.SemanticAnalysis.UnitTests.csproj", "{DE0352C7-509B-4BAE-B9E2-5EA4343E788B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cle.UnitTests.Common", "test\Cle.UnitTests.Common\Cle.UnitTests.Common.csproj", "{50038DC7-5193-47CD-A789-E289BE181CC0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cle.UnitTests.Common", "test\Cle.UnitTests.Common\Cle.UnitTests.Common.csproj", "{50038DC7-5193-47CD-A789-E289BE181CC0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cle.Frontend.UnitTests", "test\Cle.Frontend.UnitTests\Cle.Frontend.UnitTests.csproj", "{9C8387AA-EB58-4819-AAF5-16B6A6CFD348}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cle.Frontend.UnitTests", "test\Cle.Frontend.UnitTests\Cle.Frontend.UnitTests.csproj", "{9C8387AA-EB58-4819-AAF5-16B6A6CFD348}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cle.CodeGeneration", "src\Cle.CodeGeneration\Cle.CodeGeneration.csproj", "{17745E6B-C653-4901-AF80-354DEDF216C9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cle.CodeGeneration", "src\Cle.CodeGeneration\Cle.CodeGeneration.csproj", "{17745E6B-C653-4901-AF80-354DEDF216C9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cle.CodeGeneration.UnitTests", "test\Cle.CodeGeneration.UnitTests\Cle.CodeGeneration.UnitTests.csproj", "{7D8A881D-B443-4A88-8F18-AF6D22038389}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cle.CodeGeneration.UnitTests", "test\Cle.CodeGeneration.UnitTests\Cle.CodeGeneration.UnitTests.csproj", "{7D8A881D-B443-4A88-8F18-AF6D22038389}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cle.IntegrationTests", "test\Cle.IntegrationTests\Cle.IntegrationTests.csproj", "{8EDA47F3-EC94-45B0-8F51-CB397A84EB6B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cle.IntegrationTests", "test\Cle.IntegrationTests\Cle.IntegrationTests.csproj", "{8EDA47F3-EC94-45B0-8F51-CB397A84EB6B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Cle.CodeGeneration/Lir/LowBlock.cs
+++ b/src/Cle.CodeGeneration/Lir/LowBlock.cs
@@ -13,7 +13,7 @@ namespace Cle.CodeGeneration.Lir
         /// Gets a linear list of lowered instructions in this block.
         /// </summary>
         [NotNull]
-        public List<LowInstruction> Instructions = new List<LowInstruction>();
+        public readonly List<LowInstruction> Instructions;
 
         /// <summary>
         /// Gets a read-only list of Phi nodes executed at the start of this block.
@@ -21,5 +21,26 @@ namespace Cle.CodeGeneration.Lir
         /// </summary>
         [CanBeNull, ItemNotNull]
         public IReadOnlyList<Phi> Phis;
+
+        /// <summary>
+        /// Gets a list of predecessors of this basic block.
+        /// </summary>
+        [NotNull]
+        public IReadOnlyList<int> Predecessors;
+
+        /// <summary>
+        /// Gets a list of successors of this basic block.
+        /// </summary>
+        [NotNull]
+        public IReadOnlyList<int> Successors;
+
+        public LowBlock() : this(new List<LowInstruction>())
+        {
+        }
+
+        public LowBlock(List<LowInstruction> instructions)
+        {
+            Instructions = instructions;
+        }
     }
 }

--- a/src/Cle.CodeGeneration/Lir/LowInstruction.cs
+++ b/src/Cle.CodeGeneration/Lir/LowInstruction.cs
@@ -30,7 +30,8 @@ namespace Cle.CodeGeneration.Lir
         /// <summary>
         /// Returns whether <see cref="Right"/> refers to a local.
         /// </summary>
-        public bool UsesRight => Op == LowOp.Compare || Op == LowOp.IntegerAdd || Op == LowOp.IntegerSubtract;
+        public bool UsesRight => Op == LowOp.Swap || Op == LowOp.Compare ||
+            Op == LowOp.IntegerAdd || Op == LowOp.IntegerSubtract;
 
         /// <summary>
         /// Returns whether <see cref="Dest"/> refers to a local.
@@ -99,6 +100,10 @@ namespace Cle.CodeGeneration.Lir
         /// Moves the value in Left to Dest.
         /// </summary>
         Move,
+        /// <summary>
+        /// Swaps Left and Right.
+        /// </summary>
+        Swap,
 
         // Arithmetic
 

--- a/src/Cle.CodeGeneration/Lir/LowInstruction.cs
+++ b/src/Cle.CodeGeneration/Lir/LowInstruction.cs
@@ -38,7 +38,8 @@ namespace Cle.CodeGeneration.Lir
         /// </summary>
         public bool UsesDest => Op == LowOp.LoadInt || Op == LowOp.Move ||
                                 Op == LowOp.IntegerAdd || Op == LowOp.IntegerSubtract ||
-                                Op == LowOp.SetIfEqual || Op == LowOp.Call;
+                                (Op >= LowOp.SetIfEqual && Op <= LowOp.SetIfGreaterOrEqual) || 
+                                Op == LowOp.Call;
 
         public override bool Equals(object obj)
         {

--- a/src/Cle.CodeGeneration/Lir/LowLocal.cs
+++ b/src/Cle.CodeGeneration/Lir/LowLocal.cs
@@ -8,11 +8,12 @@ namespace Cle.CodeGeneration.Lir
     {
         public readonly TypeDefinition Type;
 
-        public StorageLocation<TRegister> Location;
+        public readonly StorageLocation<TRegister> RequiredLocation;
 
-        public LowLocal(TypeDefinition type)
+        public LowLocal(TypeDefinition type, StorageLocation<TRegister> requiredLocation = default)
         {
             Type = type;
+            RequiredLocation = requiredLocation;
         }
     }
 }

--- a/src/Cle.CodeGeneration/Lir/LowMethod.cs
+++ b/src/Cle.CodeGeneration/Lir/LowMethod.cs
@@ -23,12 +23,17 @@ namespace Cle.CodeGeneration.Lir
         /// <summary>
         /// Prints a debugging representation of this method to the given writer.
         /// </summary>
-        public void Dump([NotNull] TextWriter writer)
+        /// <param name="writer">A writer instance.</param>
+        /// <param name="printLocals">If true, the locals and their required locations will be printed.</param>
+        public void Dump([NotNull] TextWriter writer, bool printLocals)
         {
-            for (var i = 0; i < Locals.Count; i++)
+            if (printLocals)
             {
-                var local = Locals[i];
-                writer.WriteLine($"; #{i} {local.Type.TypeName} [{local.Location}]");
+                for (var i = 0; i < Locals.Count; i++)
+                {
+                    var local = Locals[i];
+                    writer.WriteLine($"; #{i} {local.Type.TypeName} [{local.RequiredLocation}]");
+                }
             }
 
             for (var i = 0; i < Blocks.Count; i++)

--- a/src/Cle.CodeGeneration/Lir/LowMethod.cs
+++ b/src/Cle.CodeGeneration/Lir/LowMethod.cs
@@ -15,10 +15,21 @@ namespace Cle.CodeGeneration.Lir
         where TRegister : struct, Enum
     {
         [NotNull, ItemNotNull]
-        public readonly List<LowLocal<TRegister>> Locals = new List<LowLocal<TRegister>>();
+        public readonly List<LowLocal<TRegister>> Locals;
 
         [NotNull, ItemNotNull]
-        public readonly List<LowBlock> Blocks = new List<LowBlock>();
+        public readonly List<LowBlock> Blocks;
+
+        public LowMethod()
+            : this(new List<LowLocal<TRegister>>(), new List<LowBlock>())
+        {
+        }
+
+        public LowMethod(List<LowLocal<TRegister>> locals, List<LowBlock> blocks)
+        {
+            Locals = locals;
+            Blocks = blocks;
+        }
 
         /// <summary>
         /// Prints a debugging representation of this method to the given writer.

--- a/src/Cle.CodeGeneration/Lir/LowMethod.cs
+++ b/src/Cle.CodeGeneration/Lir/LowMethod.cs
@@ -41,7 +41,7 @@ namespace Cle.CodeGeneration.Lir
                 writer.WriteLine("LB_" + i + ":");
                 foreach (var instr in Blocks[i].Instructions)
                 {
-                    writer.WriteLine($"    {instr.Op} {instr.Left} {instr.Right} {instr.Data} -> {instr.Dest}");
+                    writer.WriteLine("    " + instr);
                 }
             }
         }

--- a/src/Cle.CodeGeneration/Lir/StorageLocation.cs
+++ b/src/Cle.CodeGeneration/Lir/StorageLocation.cs
@@ -24,6 +24,9 @@ namespace Cle.CodeGeneration.Lir
             Register = register;
         }
 
+        public static implicit operator StorageLocation<TRegister>(TRegister register)
+            => new StorageLocation<TRegister>(register);
+
         public StorageLocation(int stackOffset)
         {
             _stackOffset = stackOffset + 1;

--- a/src/Cle.CodeGeneration/LoweringX64.cs
+++ b/src/Cle.CodeGeneration/LoweringX64.cs
@@ -80,10 +80,8 @@ namespace Cle.CodeGeneration
                 // This assumes that the first paramCount locals are the parameters
                 for (var i = 0; i < paramCount; i++)
                 {
-                    methodInProgress.Locals.Add(new LowLocal<X64Register>(highMethod.Values[i].Type)
-                    {
-                        Location = GetLocationForParameter(i)
-                    });
+                    methodInProgress.Locals.Add(
+                        new LowLocal<X64Register>(highMethod.Values[i].Type, GetLocationForParameter(i)));
                     var tempIndex = methodInProgress.Locals.Count - 1;
 
                     lowBlock.Instructions.Add(new LowInstruction(LowOp.Move, i, tempIndex, 0, 0));
@@ -204,8 +202,7 @@ namespace Cle.CodeGeneration
             if (!returnValue.Type.Equals(SimpleType.Void))
             {
                 var dest = methodInProgress.Locals.Count;
-                methodInProgress.Locals.Add(new LowLocal<X64Register>(returnValue.Type)
-                    { Location = new StorageLocation<X64Register>(X64Register.Rax) });
+                methodInProgress.Locals.Add(new LowLocal<X64Register>(returnValue.Type, X64Register.Rax));
 
                 lowBlock.Instructions.Add(new LowInstruction(LowOp.Move, dest, valueIndex, 0, 0));
             }
@@ -222,10 +219,8 @@ namespace Cle.CodeGeneration
             for (var i = 0; i < callInfo.ParameterIndices.Length; i++)
             {
                 var paramIndex = callInfo.ParameterIndices[i];
-                methodInProgress.Locals.Add(new LowLocal<X64Register>(methodInProgress.Locals[paramIndex].Type)
-                {
-                    Location = GetLocationForParameter(i)
-                });
+                methodInProgress.Locals.Add(new LowLocal<X64Register>(methodInProgress.Locals[paramIndex].Type,
+                   GetLocationForParameter(i)));
 
                 lowBlock.Instructions.Add(new LowInstruction(LowOp.Move, methodInProgress.Locals.Count - 1, paramIndex, 0, 0));
             }
@@ -235,10 +230,8 @@ namespace Cle.CodeGeneration
             // Then, unless the method returns void, do the same for the return value
             if (!methodInProgress.Locals[dest].Type.Equals(SimpleType.Void))
             {
-                methodInProgress.Locals.Add(new LowLocal<X64Register>(methodInProgress.Locals[dest].Type)
-                {
-                    Location = new StorageLocation<X64Register>(X64Register.Rax)
-                });
+                methodInProgress.Locals.Add(
+                    new LowLocal<X64Register>(methodInProgress.Locals[dest].Type, X64Register.Rax));
 
                 lowBlock.Instructions.Add(new LowInstruction(LowOp.Move, dest, methodInProgress.Locals.Count - 1, 0, 0));
             }

--- a/src/Cle.CodeGeneration/LoweringX64.cs
+++ b/src/Cle.CodeGeneration/LoweringX64.cs
@@ -38,7 +38,11 @@ namespace Cle.CodeGeneration
 
                 if (highBlock is null)
                 {
-                    lowMethod.Blocks.Add(new LowBlock());
+                    lowMethod.Blocks.Add(new LowBlock()
+                    {
+                        Predecessors = Array.Empty<int>(),
+                        Successors = Array.Empty<int>()
+                    });
                 }
                 else
                 {
@@ -71,8 +75,23 @@ namespace Cle.CodeGeneration
         {
             var lowBlock = new LowBlock
             {
-                Phis = highBlock.Phis
+                Phis = highBlock.Phis,
+                Predecessors = highBlock.Predecessors
             };
+
+            // Initialize the list of successors
+            if (highBlock.AlternativeSuccessor >= 0)
+            {
+                lowBlock.Successors = new[] { highBlock.AlternativeSuccessor, highBlock.DefaultSuccessor };
+            }
+            else if (highBlock.DefaultSuccessor >= 0)
+            {
+                lowBlock.Successors = new[] { highBlock.DefaultSuccessor };
+            }
+            else
+            {
+                lowBlock.Successors = Array.Empty<int>();
+            }
 
             // At the start of the first block, we must copy parameters from fixed-location temps to freely assigned locals
             if (isFirstBlock)

--- a/src/Cle.CodeGeneration/PeepholeOptimizer.cs
+++ b/src/Cle.CodeGeneration/PeepholeOptimizer.cs
@@ -100,15 +100,15 @@ namespace Cle.CodeGeneration
                         block.RemoveAt(currentPos);
                         return true;
                     }
-                    else if (current.Op == LowOp.SetIfEqual && next.Left == current.Dest && localUses[current.Dest] == 1)
+                    else if (IsConditionalSet(current.Op) && next.Left == current.Dest && localUses[current.Dest] == 1)
                     {
                         // When #0 is used only in the move instruction
                         // ----
-                        // SetIfEqual -> #0
+                        // SetIfXXX -> #0
                         // Move #0 -> #1
                         // ----
-                        // SetIfEqual -> #1
-                        block[currentPos + 1] = new LowInstruction(LowOp.SetIfEqual, next.Dest, 0, 0, 0);
+                        // SetIfXXX -> #1
+                        block[currentPos + 1] = new LowInstruction(current.Op, next.Dest, 0, 0, 0);
                         block.RemoveAt(currentPos);
                         return true;
                     }

--- a/src/Cle.CodeGeneration/PeepholeOptimizer.cs
+++ b/src/Cle.CodeGeneration/PeepholeOptimizer.cs
@@ -7,6 +7,7 @@ namespace Cle.CodeGeneration
 {
     /// <summary>
     /// Peephole optimization of LIR for the x64 architecture.
+    /// This optimization pass is run before register allocation.
     /// </summary>
     internal static class PeepholeOptimizer<TRegister>
         where TRegister: struct, Enum
@@ -36,7 +37,7 @@ namespace Cle.CodeGeneration
             // For example, the Return op implicitly uses the local stored in the return register
             for (var i = 0; i < method.Locals.Count; i++)
             {
-                if (method.Locals[i].Location.IsSet)
+                if (method.Locals[i].RequiredLocation.IsSet)
                     uses[i] += 100; // Distinguish from ordinary locals
             }
 

--- a/src/Cle.CodeGeneration/RegisterAllocation/AllocationInfo.cs
+++ b/src/Cle.CodeGeneration/RegisterAllocation/AllocationInfo.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using Cle.CodeGeneration.Lir;
+
+namespace Cle.CodeGeneration.RegisterAllocation
+{
+    /// <summary>
+    /// Contains the allocation decisions for local variables as a map from allocator-provided
+    /// indices to local indices and locations.
+    /// </summary>
+    internal class AllocationInfo<TRegister>
+        where TRegister : struct, Enum
+    {
+        public int IntervalCount => _intervals.Count;
+
+        private readonly List<Interval<TRegister>> _intervals;
+
+        /// <param name="intervals">The list must match the value numbers in low instructions.</param>
+        internal AllocationInfo(List<Interval<TRegister>> intervals)
+        {
+            _intervals = intervals;
+        }
+
+        /// <summary>
+        /// Gets the storage location and local variable index for the given value number generated
+        /// by the register allocator. The local index may be zero if the value does not map to a local.
+        /// </summary>
+        /// <param name="index">The value index set by the register allocator.</param>
+        public (StorageLocation<TRegister> location, int localIndex) Get(int index)
+        {
+            var interval = _intervals[index];
+            return (new StorageLocation<TRegister>(interval.Register), interval.LocalIndex);
+        }
+    }
+}

--- a/src/Cle.CodeGeneration/RegisterAllocation/AllocationInfo.cs
+++ b/src/Cle.CodeGeneration/RegisterAllocation/AllocationInfo.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using Cle.CodeGeneration.Lir;
+using JetBrains.Annotations;
 
 namespace Cle.CodeGeneration.RegisterAllocation
 {
@@ -13,10 +15,11 @@ namespace Cle.CodeGeneration.RegisterAllocation
     {
         public int IntervalCount => _intervals.Count;
 
+        [NotNull, ItemNotNull]
         private readonly List<Interval<TRegister>> _intervals;
 
         /// <param name="intervals">The list must match the value numbers in low instructions.</param>
-        internal AllocationInfo(List<Interval<TRegister>> intervals)
+        internal AllocationInfo([NotNull, ItemNotNull] List<Interval<TRegister>> intervals)
         {
             _intervals = intervals;
         }
@@ -30,6 +33,14 @@ namespace Cle.CodeGeneration.RegisterAllocation
         {
             var interval = _intervals[index];
             return (new StorageLocation<TRegister>(interval.Register), interval.LocalIndex);
+        }
+
+        internal void Dump([NotNull] TextWriter dumpWriter)
+        {
+            foreach (var interval in _intervals)
+            {
+                dumpWriter.WriteLine("; " + interval);
+            }
         }
     }
 }

--- a/src/Cle.CodeGeneration/RegisterAllocation/Interval.cs
+++ b/src/Cle.CodeGeneration/RegisterAllocation/Interval.cs
@@ -1,0 +1,45 @@
+﻿using System;
+
+namespace Cle.CodeGeneration.RegisterAllocation
+{
+    /// <summary>
+    /// For register allocator internal use only; the public interface is <see cref="AllocationInfo{TRegister}"/>.
+    /// A MUTABLE CLASS representing a single live interval and its allocation decision.
+    /// </summary>
+    internal class Interval<TRegister> : IComparable<Interval<TRegister>>
+        where TRegister : struct, Enum
+    {
+        public int Start = -1;
+        public int End = -1;
+        public int LocalIndex = -1;
+        public TRegister Register;
+
+        /// <summary>
+        /// Updates the start and end positions.
+        /// </summary>
+        public void Use(int index)
+        {
+            Start = Start == -1 ? index : Math.Min(Start, index);
+            End = Math.Max(End, index);
+        }
+
+        /// <summary>
+        /// Extends the lifetime of this interval to include the given interval.
+        /// </summary>
+        public void MergeWith(Interval<TRegister> other)
+        {
+            Use(other.Start);
+            Use(other.End);
+        }
+
+        public int CompareTo(Interval<TRegister> other)
+        {
+            return Start.CompareTo(other.Start);
+        }
+
+        public override string ToString()
+        {
+            return $"[{Start}, {End}) #{LocalIndex} in {Register}";
+        }
+    }
+}

--- a/src/Cle.CodeGeneration/RegisterAllocation/X64RegisterAllocator.cs
+++ b/src/Cle.CodeGeneration/RegisterAllocation/X64RegisterAllocator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Cle.CodeGeneration.Lir;
 using JetBrains.Annotations;
 
@@ -10,17 +11,22 @@ namespace Cle.CodeGeneration.RegisterAllocation
     /// <summary>
     /// Register allocator for the x64 architecture.
     /// </summary>
+    /// <remarks>
+    /// This is modeled after Wimmer and Franz: Linear Scan Register Allocation on SSA Form (CGO '10, ACM),
+    /// with some simplifications.
+    /// </remarks>
     internal static class X64RegisterAllocator
     {
         // Registers are ordered in decreasing preference with regards to two conditions:
         //   - basic registers are preferred over new registers (r8-15) for shorter encoding
         //   - volatile registers are preferred over callee-saved registers to avoid pushing/popping
+        //   - additionally, rcx and rdx are preferred over rax since a lot of loads are for parameters
         // This should increase code quality but does cause extra work in allocation (more conflicts)
         private static readonly int[] s_preferredIntegerRegisterOrder =
         {
-            (int)X64Register.Rax,
             (int)X64Register.Rcx,
             (int)X64Register.Rdx,
+            (int)X64Register.Rax,
             (int)X64Register.R8,
             (int)X64Register.R9,
             (int)X64Register.Rdi,
@@ -46,45 +52,235 @@ namespace Cle.CodeGeneration.RegisterAllocation
         public static (LowMethod<X64Register> allocatedMethod, AllocationInfo<X64Register> allocationInfo)
             Allocate([NotNull] LowMethod<X64Register> method)
         {
-            /* TODO: This is a quick-and-dirty linear scan register allocator for the initial bring-up!
-             * Features:
-             *   - does NOT support spilling to stack (!)
-             *   - does NOT support splitting live intervals
-             *   - is NOT mathematically proven correct
-             *   - handles Phis by merging the operand and result locals for the purposes of allocation
-             */
-            
             // Compute the live intervals
             var intervals = new List<Interval>(method.Locals.Count);
-            var localToAllocatedLocalMap = new int[method.Locals.Count];
-            for (var i = 0; i < method.Locals.Count; i++)
-            {
-                intervals.Add(new Interval { LocalIndex = i, Register = method.Locals[i].RequiredLocation.Register });
-                localToAllocatedLocalMap[i] = i;
-            }
-
-            ComputeLiveIntervals(method, intervals, localToAllocatedLocalMap);
+            var blockEnds = new int[method.Blocks.Count];
+            ComputeLiveIntervals(method, intervals, blockEnds);
 
             // Sort the intervals by start position
-            for (var i = intervals.Count - 1; i >= 0; i--)
-            {
-                if (intervals[i] is null)
-                    intervals.RemoveAt(i);
-            }
             intervals.Sort();
 
             // Allocate registers by doing a linear scan
+            DoLinearScan(intervals);
+
+            // Rewrite the method to use interval numbers instead of local indices
+            // This also resolves Phi functions by converting them into moves/swaps
+            var rewrittenMethod = RewriteMethod(method, intervals, blockEnds);
+
+            return (rewrittenMethod, new AllocationInfo<X64Register>(intervals));
+        }
+
+        /// <summary>
+        /// Phase 1: Compute live intervals.
+        /// Each interval maps to a single local in a contiguous region of instructions.
+        /// The regions are defined by instruction counts, where the set of Phis is considered one instruction.
+        /// </summary>
+        /// <param name="method">The original LIR method where instructions refer to locals.</param>
+        /// <param name="intervals">An empty list that will be populated by the computed intervals.</param>
+        /// <param name="blockEnds">
+        /// An empty array that has an element for each block.
+        /// This will be populated with the last instruction index (inclusive) of each basic block.
+        /// </param>
+        private static void ComputeLiveIntervals(LowMethod<X64Register> method,
+            List<Interval> intervals, int[] blockEnds)
+        {
+            // We must start from the maximum index as we traverse the blocks in reverse order
+            // NOTE: This complicates the instruction counting quite a bit, so be careful!
+            var instIndex = 0;
+            foreach (var block in method.Blocks)
+                instIndex += block.Instructions.Count + 1;
+
+            // TODO: Is this a sensible design correctness/performance-wise?
+            var latestIntervalForLocal = new int[method.Locals.Count];
+            for (var i = 0; i < latestIntervalForLocal.Length; i++)
+                latestIntervalForLocal[i] = -1;
+
+            // A temporary data structure - this is not updated by the loop header handling
+            var liveIn = new SortedSet<int>[method.Blocks.Count];
+            for (var i = 0; i < liveIn.Length; i++)
+                liveIn[i] = new SortedSet<int>();
+
+            // The reverse order is used because it typically sees block successors first
+            for (var blockIndex = method.Blocks.Count - 1; blockIndex >= 0; blockIndex--)
+            {
+                var block = method.Blocks[blockIndex];
+                var blockEnd = instIndex - 1;
+                blockEnds[blockIndex] = blockEnd;
+                var blockStart = blockEnd - block.Instructions.Count;
+                var live = liveIn[blockIndex];
+
+                // Initialize the live set to contain all locals that are live at the beginning of some
+                // succeeding block, and all locals used in Phis of the succeeding blocks
+                if (block.Successors is object)
+                {
+                    foreach (var succ in block.Successors)
+                    {
+                        live.UnionWith(liveIn[succ]);
+
+                        if (method.Blocks[succ].Phis is null)
+                            continue;
+
+                        var phiPosition = GetPhiOperandIndex(blockIndex, method.Blocks[succ]);
+                        foreach (var phi in method.Blocks[succ].Phis)
+                            live.Add(phi.Operands[phiPosition]);
+                    }
+                }
+
+                // Create an interval for each live local
+                // TODO: Consider merging adjacent intervals of a single local
+                foreach (var liveLocal in live)
+                {
+                    AddIntervalForLocal(liveLocal, blockStart, blockEnd);
+                }
+
+                // Then go through the instructions in reverse order
+                for (var j = block.Instructions.Count - 1; j >= 0; j--)
+                {
+                    var inst = block.Instructions[j];
+                    instIndex--;
+
+                    // Since the LIR is in SSA form, the output operand is not live before this instruction
+                    if (inst.UsesDest)
+                    {
+                        if (latestIntervalForLocal[inst.Dest] == -1)
+                        {
+                            // If the result local is not used anywhere, we need to create a short interval here
+                            AddIntervalForLocal(inst.Dest, instIndex, instIndex);
+                        }
+                        else
+                        {
+                            intervals[latestIntervalForLocal[inst.Dest]].Start = instIndex;
+                        }
+
+                        live.Remove(inst.Dest);
+                    }
+
+                    // Input operands are defined before their uses, so we only need to add an interval
+                    // if the local is not yet live. Initially we set the lifetime to start at the start
+                    // of the block, but this may be shortened if the local is defined in this block.
+                    if (inst.UsesLeft && !live.Contains(inst.Left))
+                    {
+                        AddIntervalForLocal(inst.Left, blockStart, instIndex);
+                        live.Add(inst.Left);
+                    }
+                    if (inst.UsesRight && !live.Contains(inst.Right))
+                    {
+                        AddIntervalForLocal(inst.Right, blockStart, instIndex);
+                        live.Add(inst.Right);
+                    }
+
+                    // Prevent X64 trashing the right operand of subtraction (see associated unit test)
+                    if (inst.Op == LowOp.IntegerSubtract)
+                    {
+                        intervals[latestIntervalForLocal[inst.Right]].Use(instIndex + 1);
+                    }
+
+                    // Calls trash some registers, so we need to add intervals for them
+                    if (inst.Op == LowOp.Call)
+                    {
+                        // RAX is already reserved as the call result is stored in a local
+                        intervals.Add(new Interval { Start = instIndex, End = instIndex, Register = X64Register.Rcx });
+                        intervals.Add(new Interval { Start = instIndex, End = instIndex, Register = X64Register.Rdx });
+                        intervals.Add(new Interval { Start = instIndex, End = instIndex, Register = X64Register.R8 });
+                        intervals.Add(new Interval { Start = instIndex, End = instIndex, Register = X64Register.R9 });
+                        intervals.Add(new Interval { Start = instIndex, End = instIndex, Register = X64Register.R10 });
+                        intervals.Add(new Interval { Start = instIndex, End = instIndex, Register = X64Register.R11 });
+                    }
+                }
+
+                // Remove Phi outputs from the live set
+                if (block.Phis is object)
+                {
+                    foreach (var phi in block.Phis)
+                    {
+                        intervals[latestIntervalForLocal[phi.Destination]].Use(instIndex - 1);
+                        live.Remove(phi.Destination);
+                    }
+                }
+
+                // The set of Phis is a single instruction (even if empty)
+                instIndex--;
+                Debug.Assert(instIndex == blockStart);
+
+                // If this block is a loop header (has a predecessor with greater block index, or is
+                // its own predecessor), extend the lifetimes of locals that are live for the entire loop
+                foreach (var predIndex in block.Predecessors)
+                {
+                    if (predIndex < blockIndex)
+                        continue;
+
+                    foreach (var liveLocal in live)
+                    {
+                        AddIntervalForLocal(liveLocal, blockStart, blockEnds[predIndex]);
+                    }
+                }
+            }
+
+            Debug.Assert(instIndex == 0);
+
+            void AddIntervalForLocal(int localIndex, int start, int end)
+            {
+                // If there already is an adjacent interval, update it instead of creating another
+                // TODO: Is looking up in this cache enough?
+                if (latestIntervalForLocal[localIndex] >= 0)
+                {
+                    var existing = intervals[latestIntervalForLocal[localIndex]];
+                    if (existing.Start <= end + 1 && existing.End >= start - 1)
+                    {
+                        existing.Use(start);
+                        existing.Use(end);
+                        return;
+                    }
+                }
+
+                // Else, create a new interval
+                intervals.Add(new Interval()
+                {
+                    LocalIndex = localIndex,
+                    Register = method.Locals[localIndex].RequiredLocation.Register,
+                    Start = start,
+                    End = end
+                });
+                latestIntervalForLocal[localIndex] = intervals.Count - 1;
+            }
+        }
+
+        /// <summary>
+        /// phiBlock.Predecessors.IndexOf(blockIndex)
+        /// </summary>
+        private static int GetPhiOperandIndex(int blockIndex, LowBlock phiBlock)
+        {
+            for (var j = 0; j < phiBlock.Predecessors.Count; j++)
+            {
+                if (phiBlock.Predecessors[j] == blockIndex)
+                    return j;
+            }
+
+            throw new InvalidOperationException("Successors and predecessors do not match.");
+        }
+
+        /// <summary>
+        /// Phase 2: Allocate storage locations for intervals.
+        /// This is a standard linear scan algorithm.
+        /// </summary>
+        /// <param name="intervals">
+        /// The list of intervals with lifetimes and possible register requirements.
+        /// This list must be sorted by increasing start position.
+        /// </param>
+        private static void DoLinearScan(List<Interval<X64Register>> intervals)
+        {
             var live = new List<Interval>();
             var freeSince = new int[(int)X64Register.Count];
             var registerUsers = new int[(int)X64Register.Count];
             for (var i = 0; i < registerUsers.Length; i++)
                 registerUsers[i] = -1;
 
+            // Loop through the intervals in order of start position
             for (var intervalIndex = 0; intervalIndex < intervals.Count; intervalIndex++)
             {
                 var interval = intervals[intervalIndex];
 
-                // Remove intervals that have ended
+                // Remove intervals that have ended before (or at) this position
                 for (var i = live.Count - 1; i >= 0; i--)
                 {
                     if (live[i].End <= interval.Start)
@@ -100,107 +296,9 @@ namespace Cle.CodeGeneration.RegisterAllocation
                 // TODO: Consider sorting the live list by interval end
                 live.Add(interval);
 
-                // Find a register for the current interval
+                // Find a register for the current interval, possibly reallocating
+                // another, blocking interval
                 AllocateInterval(intervalIndex, intervals, registerUsers, freeSince);
-            }
-
-            // Return the allocation decisions
-            // TODO: Actually rewrite the method - this is a temporary WIP solution
-            var tempIntervalList = new Interval<X64Register>[method.Locals.Count];
-            foreach (var interval in intervals)
-            {
-                if (interval.LocalIndex >= 0)
-                {
-                    tempIntervalList[interval.LocalIndex] = interval;
-                }
-            }
-            for (var i = 0; i < localToAllocatedLocalMap.Length; i++)
-            {
-                var copySource = tempIntervalList[localToAllocatedLocalMap[i]];
-                tempIntervalList[i] = new Interval<X64Register>()
-                {
-                    Start = copySource.Start,
-                    End = copySource.End,
-                    LocalIndex = i,
-                    Register = copySource.Register
-                };
-            }
-
-            var allocationInfo = new AllocationInfo<X64Register>(new List<Interval<X64Register>>(tempIntervalList));
-            return (method, allocationInfo);
-        }
-
-        private static void ComputeLiveIntervals(LowMethod<X64Register> method, List<Interval> intervals, int[] localToAllocatedLocalMap)
-        {
-            var instIndex = 0;
-            foreach (var block in method.Blocks)
-            {
-                // Phis: each phi is a use location for each operand (and destination)
-                if (!(block.Phis is null))
-                {
-                    foreach (var phi in block.Phis)
-                    {
-                        intervals[phi.Destination].Use(instIndex);
-                        foreach (var op in phi.Operands)
-                        {
-                            intervals[op].Use(instIndex);
-
-                            // Now the phi operand has the same register as its destination
-                            var parent = localToAllocatedLocalMap[phi.Destination];
-                            localToAllocatedLocalMap[op] = parent;
-
-                            // We also need to update all the locals that depend on the phi operand
-                            // THIS IS O(N^2), but for high N this algorithm is expected to fail anyways
-                            for (var j = 0; j < localToAllocatedLocalMap.Length; j++)
-                            {
-                                if (localToAllocatedLocalMap[j] == op)
-                                    localToAllocatedLocalMap[j] = parent;
-                            }
-                        }
-                    }
-                }
-
-                instIndex++;
-
-                // Then go through the instructions
-                foreach (var inst in block.Instructions)
-                {
-                    if (inst.UsesLeft)
-                        intervals[inst.Left].Use(instIndex);
-                    if (inst.UsesRight)
-                        intervals[inst.Right].Use(instIndex);
-                    if (inst.UsesDest)
-                        intervals[inst.Dest].Use(instIndex);
-
-                    // Prevent X64 trashing the right operand of subtraction (see associated unit test)
-                    if (inst.Op == LowOp.IntegerSubtract)
-                        intervals[inst.Right].Use(instIndex + 1);
-
-                    // Calls trash some registers, so we need to add intervals for them
-                    if (inst.Op == LowOp.Call)
-                    {
-                        // RAX is already reserved as the call result is stored in a local
-                        intervals.Add(new Interval { Start = instIndex, End = instIndex, Register = X64Register.Rcx });
-                        intervals.Add(new Interval { Start = instIndex, End = instIndex, Register = X64Register.Rdx });
-                        intervals.Add(new Interval { Start = instIndex, End = instIndex, Register = X64Register.R8 });
-                        intervals.Add(new Interval { Start = instIndex, End = instIndex, Register = X64Register.R9 });
-                        intervals.Add(new Interval { Start = instIndex, End = instIndex, Register = X64Register.R10 });
-                        intervals.Add(new Interval { Start = instIndex, End = instIndex, Register = X64Register.R11 });
-                    }
-
-                    instIndex++;
-                }
-            }
-
-            // Merge the intervals of Phi operands
-            // TODO: This does not handle register requirements of operands gracefully (there shouldn't be any)
-            for (var i = localToAllocatedLocalMap.Length - 1; i >= 0; i--)
-            {
-                if (localToAllocatedLocalMap[i] == i)
-                    continue;
-
-                intervals[localToAllocatedLocalMap[i]].MergeWith(intervals[i]);
-                intervals[i] = null;
             }
         }
 
@@ -211,7 +309,7 @@ namespace Cle.CodeGeneration.RegisterAllocation
             if (intervals[intervalIndex].Register > X64Register.Invalid)
             {
                 var blocker = registerUsers[(int)intervals[intervalIndex].Register];
-                
+
                 ReserveRegister((int)intervals[intervalIndex].Register, intervalIndex, registerUsers, freeSince);
 
                 if (blocker == -1)
@@ -234,7 +332,7 @@ namespace Cle.CodeGeneration.RegisterAllocation
                         }
                     }
 
-                    throw new NotImplementedException("How to proceed with this case?");
+                    throw new NotImplementedException("Spilling a blocker to stack");
                 }
             }
 
@@ -249,14 +347,217 @@ namespace Cle.CodeGeneration.RegisterAllocation
                 }
             }
 
-            // If that failed, we need to spill a local
-            throw new NotImplementedException("Spilling locals");
+            // If that failed, we need to spill the interval onto stack
+            throw new NotImplementedException("Spilling to stack");
         }
 
         private static void ReserveRegister(int registerIndex, int intervalIndex, int[] registerUsers, int[] freeSince)
         {
             registerUsers[registerIndex] = intervalIndex;
             freeSince[registerIndex] = int.MaxValue;
+        }
+
+        /// <summary>
+        /// Phase 3: Rewrite the instructions to reference intervals and convert Phis to moves.
+        /// </summary>
+        /// <param name="original">The original LIR method that was passed to the allocator.</param>
+        /// <param name="intervals">The list of intervals with allocation decisions done.</param>
+        /// <param name="blockEnds">
+        /// The block ends computed by
+        /// <see cref="ComputeLiveIntervals(LowMethod{X64Register}, List{Interval{X64Register}}, int[])"/>.
+        /// </param>
+        private static LowMethod<X64Register> RewriteMethod(LowMethod<X64Register> original,
+            List<Interval> intervals, int[] blockEnds)
+        {
+            var result = new LowMethod<X64Register>(original.Locals, new List<LowBlock>(original.Blocks.Count));
+
+            // Replace instruction operands with references to intervals instead of locals
+            var instIndex = 0;
+            for (var blockIndex = 0; blockIndex < original.Blocks.Count; blockIndex++)
+            {
+                // TODO: Account for instructions emitted by Phi resolution in the capacity calculation
+                var oldBlock = original.Blocks[blockIndex];
+                var newBlock = new LowBlock(new List<LowInstruction>(oldBlock.Instructions.Count))
+                {
+                    Phis = oldBlock.Phis, // This is required in ConvertPhisToMoves but then nulled out
+                    Predecessors = oldBlock.Predecessors,
+                    Successors = oldBlock.Successors
+                };
+
+                instIndex++;
+
+                foreach (var inst in oldBlock.Instructions)
+                {
+                    newBlock.Instructions.Add(new LowInstruction(inst.Op,
+                        inst.UsesDest ? ConvertLocalToInterval(inst.Dest, intervals, instIndex) : inst.Dest,
+                        inst.UsesLeft ? ConvertLocalToInterval(inst.Left, intervals, instIndex) : inst.Left,
+                        inst.UsesRight ? ConvertLocalToInterval(inst.Right, intervals, instIndex) : inst.Right,
+                        inst.Data));
+                    instIndex++;
+                }
+
+                result.Blocks.Add(newBlock);
+            }
+
+            // Resolve Phi functions
+            ConvertPhisToMoves(result, intervals, blockEnds);
+
+            return result;
+        }
+
+
+        private static int ConvertLocalToInterval(int local, List<Interval> intervals, int position)
+        {
+            // TODO TODO TODO: This is, as used here, O(N^2) with large N!
+
+            // The intervals are sorted by start position
+            for (var i = 0; i < intervals.Count; i++)
+            {
+                var interval = intervals[i];
+
+                if (interval.LocalIndex == local && interval.Start <= position && interval.End >= position)
+                {
+                    return i;
+                }
+            }
+
+            throw new InvalidOperationException("No interval matching the local.");
+        }
+
+        private static void ConvertPhisToMoves(LowMethod<X64Register> method, List<Interval> intervals, int[] blockEnds)
+        {
+            // This also handles different locations between basic blocks
+            var movesToDo = new List<(int fromInterval, int toInterval)>();
+
+            for (var blockIndex = 0; blockIndex < method.Blocks.Count; blockIndex++)
+            {
+                var instIndex = blockIndex == 0 ? 0 : blockEnds[blockIndex - 1] + 1;
+                var block = method.Blocks[blockIndex];
+                if (block.Predecessors is null)
+                {
+                    continue;
+                }
+
+                for (var i = 0; i < block.Predecessors.Count; i++)
+                {
+                    movesToDo.Clear();
+
+                    var predIndex = block.Predecessors[i];
+                    var phiOperandIndex = GetPhiOperandIndex(predIndex, block);
+
+                    // Go through all intervals live at the start of this block
+                    for (var intervalIndex = 0; intervalIndex < intervals.Count; intervalIndex++)
+                    {
+                        var interval = intervals[intervalIndex];
+
+                        if (interval.Start == instIndex)
+                        {
+                            // If the interval starts at the very start of this block, it may be defined by a Phi
+                            // Find the Phi and add a move to resolve
+                            var foundPhi = false;
+                            if (block.Phis is object)
+                            {
+                                foreach (var phi in block.Phis)
+                                {
+                                    if (phi.Destination == interval.LocalIndex)
+                                    {
+                                        var source = ConvertLocalToInterval(phi.Operands[phiOperandIndex], intervals,
+                                            blockEnds[predIndex]);
+                                        var dest = ConvertLocalToInterval(phi.Destination, intervals, instIndex);
+
+                                        movesToDo.Add((source, dest));
+                                        foundPhi = true;
+                                        break;
+                                    }
+                                }
+                            }
+
+                            if (!foundPhi)
+                            {
+                                // Else, the interval continues the lifetime of an existing local
+                                // Since its location may have changed we need to emit a move
+                                // TODO: Skip redundant moves
+                                var source = ConvertLocalToInterval(interval.LocalIndex, intervals, blockEnds[predIndex]);
+                                movesToDo.Add((source, intervalIndex));
+                            }
+                        }
+                    }
+
+                    // Resolve the moves
+                    var pred = method.Blocks[predIndex];
+                    if (pred.Successors.Count == 1)
+                    {
+                        // If the predecessor only has a single successor, emit the copies at the end of it
+                        // As a sanity check, we expect the jump instruction to be the last instruction of the block
+                        if (pred.Instructions[pred.Instructions.Count - 1].Op != LowOp.Jump)
+                            throw new InvalidOperationException("Expected unconditional jump at the end of block.");
+
+                        EmitRegisterMoves(movesToDo, pred.Instructions, pred.Instructions.Count - 1, intervals);
+                    }
+                    else
+                    {
+                        // Else, emit the copies at the start of this basic block
+                        // This can only succeed if this basic block has no other predecessors
+                        if (block.Predecessors.Count > 1)
+                            throw new InvalidOperationException("Critical edges must be split.");
+
+                        EmitRegisterMoves(movesToDo, block.Instructions, 0, intervals);
+                    }
+                }
+
+                // The Phi list is neither needed nor relevant any more
+                block.Phis = null;
+            }
+        }
+
+        /// <summary>
+        /// Emits necessary register moves/swaps at the requested position.
+        /// </summary>
+        /// <param name="movesToDo">The list of permutations to do. The order is not respected.</param>
+        /// <param name="instructions">The instruction list that will be modified.</param>
+        /// <param name="insertionPos">The index to the instruction list where the moves will be added.</param>
+        /// <param name="locals">The list of locals with allocation decisions.</param>
+        private static void EmitRegisterMoves(List<(int from, int to)> movesToDo,
+            List<LowInstruction> instructions, int insertionPos, List<Interval> intervals)
+        {
+            for (var i = 0; i < movesToDo.Count; i++)
+            {
+                // The trivial case - this can also arise from conflict fixups
+                var fromPos = intervals[movesToDo[i].from].Register;
+                var toPos = intervals[movesToDo[i].to].Register;
+
+                if (fromPos == toPos)
+                    continue;
+
+                // If this does not conflict with the other permutations, we can just emit a move.
+                // Else, we need to do a swap.
+                var conflicts = false;
+                for (var j = i + 1; j < movesToDo.Count; j++)
+                {
+                    if (intervals[movesToDo[j].from].Register == toPos)
+                        conflicts = true;
+                }
+
+                if (conflicts)
+                {
+                    instructions.Insert(insertionPos,
+                        new LowInstruction(LowOp.Swap, 0, movesToDo[i].from, movesToDo[i].to, 0));
+                    insertionPos++;
+
+                    // Fix all the upcoming moves to have the correct source
+                    for (var j = i + 1; j < movesToDo.Count; j++)
+                    {
+                        if (intervals[movesToDo[j].from].Register == toPos)
+                            movesToDo[j] = (movesToDo[i].from, movesToDo[j].to);
+                    }
+                }
+                else
+                {
+                    instructions.Insert(insertionPos,
+                        new LowInstruction(LowOp.Move, movesToDo[i].to, movesToDo[i].from, 0, 0));
+                    insertionPos++;
+                }
+            }
         }
     }
 }

--- a/src/Cle.CodeGeneration/RegisterAllocation/X64RegisterAllocator.cs
+++ b/src/Cle.CodeGeneration/RegisterAllocation/X64RegisterAllocator.cs
@@ -179,7 +179,7 @@ namespace Cle.CodeGeneration.RegisterAllocation
                     // Calls trash some registers, so we need to add intervals for them
                     if (inst.Op == LowOp.Call)
                     {
-                        intervals.Add(new Interval { Start = instIndex, End = instIndex, Register = X64Register.Rax });
+                        // RAX is already reserved as the call result is stored in a local
                         intervals.Add(new Interval { Start = instIndex, End = instIndex, Register = X64Register.Rcx });
                         intervals.Add(new Interval { Start = instIndex, End = instIndex, Register = X64Register.Rdx });
                         intervals.Add(new Interval { Start = instIndex, End = instIndex, Register = X64Register.R8 });

--- a/src/Cle.CodeGeneration/WindowsX64CodeGenerator.cs
+++ b/src/Cle.CodeGeneration/WindowsX64CodeGenerator.cs
@@ -131,6 +131,9 @@ namespace Cle.CodeGeneration
                             }
                             break;
                         }
+                    case LowOp.Swap:
+                        emitter.EmitExchange(allocation.Get(inst.Left).location, allocation.Get(inst.Right).location);
+                        break;
                     case LowOp.IntegerAdd:
                         EmitIntegerBinaryOp(BinaryOp.Add, in inst, method, allocation);
                         break;

--- a/src/Cle.CodeGeneration/WindowsX64CodeGenerator.cs
+++ b/src/Cle.CodeGeneration/WindowsX64CodeGenerator.cs
@@ -72,7 +72,7 @@ namespace Cle.CodeGeneration
             PeepholeOptimizer<X64Register>.Optimize(loweredMethod);
 
             // Debug log the lowering
-            if (!(dumpWriter is null))
+            if (dumpWriter is object)
             {
                 DebugLogBeforeAllocation(loweredMethod, method.FullName, dumpWriter);
             }
@@ -80,6 +80,11 @@ namespace Cle.CodeGeneration
             // Allocate registers for locals (with special casing for parameters)
             var (allocatedMethod, allocationInfo) = X64RegisterAllocator.Allocate(loweredMethod);
             DetermineRegistersToSave(allocationInfo);
+
+            if (dumpWriter is object)
+            {
+                DebugLogAfterAllocation(allocatedMethod, allocationInfo, dumpWriter);
+            }
 
             // Emit the lowered IR
             for (var i = 0; i < allocatedMethod.Blocks.Count; i++)
@@ -349,11 +354,22 @@ namespace Cle.CodeGeneration
         private static void DebugLogBeforeAllocation([NotNull] LowMethod<X64Register> loweredMethod,
             [NotNull] string methodFullName, [NotNull] TextWriter dumpWriter)
         {
-            // Dump the LIR
+            // Dump the LIR with locals
             dumpWriter.Write("; Lowered IR for ");
             dumpWriter.WriteLine(methodFullName);
 
             loweredMethod.Dump(dumpWriter, true);
+            dumpWriter.WriteLine();
+            dumpWriter.WriteLine();
+        }
+
+        private static void DebugLogAfterAllocation([NotNull] LowMethod<X64Register> allocatedMethod,
+            [NotNull] AllocationInfo<X64Register> allocationInfo, [NotNull] TextWriter dumpWriter)
+        {
+            dumpWriter.WriteLine("; After register allocation");
+
+            allocationInfo.Dump(dumpWriter);
+            allocatedMethod.Dump(dumpWriter, false);
             dumpWriter.WriteLine();
             dumpWriter.WriteLine();
         }

--- a/src/Cle.CodeGeneration/X64Emitter.cs
+++ b/src/Cle.CodeGeneration/X64Emitter.cs
@@ -122,6 +122,27 @@ namespace Cle.CodeGeneration
         }
 
         /// <summary>
+        /// Emits a full-width xchg instruction between the two registers.
+        /// </summary>
+        // TODO: This could also support the 32-bit encoding to potentially save a prefix
+        public void EmitExchange(StorageLocation<X64Register> left, StorageLocation<X64Register> right)
+        {
+            if (!right.IsRegister || !left.IsRegister)
+                throw new NotImplementedException("Xchg to/from stack");
+            if (right.Register >= X64Register.Xmm0 || left.Register >= X64Register.Xmm0)
+                throw new NotImplementedException("Xchg to/from XMM registers");
+
+            DisassembleRegReg("xchg", left.Register, right.Register, 8);
+
+            var (encodedLeft, needR) = GetRegisterEncoding(left.Register);
+            var (encodedRight, needB) = GetRegisterEncoding(right.Register);
+
+            EmitRexPrefixIfNeeded(true, needR, false, needB);
+            _outputStream.WriteByte(0x87);
+            EmitModRmForRegisterToRegister(encodedLeft, encodedRight);
+        }
+
+        /// <summary>
         /// Emits a general-purpose binary operation with the specified operand width.
         /// </summary>
         /// <param name="op">The binary operation to emit.</param>

--- a/test/Cle.CodeGeneration.UnitTests/Cle.CodeGeneration.UnitTests.csproj
+++ b/test/Cle.CodeGeneration.UnitTests/Cle.CodeGeneration.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>

--- a/test/Cle.CodeGeneration.UnitTests/Lowering/BasicLoweringX64Tests.cs
+++ b/test/Cle.CodeGeneration.UnitTests/Lowering/BasicLoweringX64Tests.cs
@@ -23,7 +23,7 @@ BB_0:
 LB_0:
     LoadInt 0 0 1234 -> 0
     Move 0 0 0 -> 1
-    Return 0 0 0 -> 0
+    Return 1 0 0 -> 0
 ";
             AssertDump(lowered, expected);
         }
@@ -51,7 +51,7 @@ LB_0:
     Test 0 0 0 -> 0
     SetIfEqual 0 0 0 -> 1
     Move 1 0 0 -> 2
-    Return 0 0 0 -> 0
+    Return 2 0 0 -> 0
 ";
             AssertDump(lowered, expected);
         }
@@ -85,7 +85,7 @@ LB_0:
     Compare 0 1 0 -> 0
     {expectedLowOp} 0 0 0 -> 2
     Move 2 0 0 -> 3
-    Return 0 0 0 -> 0
+    Return 3 0 0 -> 0
 ";
             AssertDump(lowered, expected);
         }
@@ -117,7 +117,7 @@ LB_0:
     LoadInt 0 0 5678 -> 1
     {expectedLowOp} 0 1 0 -> 2
     Move 2 0 0 -> 3
-    Return 0 0 0 -> 0
+    Return 3 0 0 -> 0
 ";
             AssertDump(lowered, expected);
         }

--- a/test/Cle.CodeGeneration.UnitTests/Lowering/BranchLoweringX64Tests.cs
+++ b/test/Cle.CodeGeneration.UnitTests/Lowering/BranchLoweringX64Tests.cs
@@ -49,11 +49,11 @@ LB_0:
 LB_1:
     LoadInt 0 0 1 -> 3
     Move 3 0 0 -> 5
-    Return 0 0 0 -> 0
+    Return 5 0 0 -> 0
 LB_2:
     LoadInt 0 0 2 -> 4
     Move 4 0 0 -> 6
-    Return 0 0 0 -> 0
+    Return 6 0 0 -> 0
 ";
             AssertDump(lowered, expected);
         }
@@ -93,11 +93,11 @@ LB_0:
 LB_1:
     LoadInt 0 0 1 -> 1
     Move 1 0 0 -> 3
-    Return 0 0 0 -> 0
+    Return 3 0 0 -> 0
 LB_2:
     LoadInt 0 0 2 -> 2
     Move 2 0 0 -> 4
-    Return 0 0 0 -> 0
+    Return 4 0 0 -> 0
 ";
             AssertDump(lowered, expected);
         }

--- a/test/Cle.CodeGeneration.UnitTests/Lowering/BranchLoweringX64Tests.cs
+++ b/test/Cle.CodeGeneration.UnitTests/Lowering/BranchLoweringX64Tests.cs
@@ -56,6 +56,13 @@ LB_2:
     Return 6 0 0 -> 0
 ";
             AssertDump(lowered, expected);
+
+            Assert.That(lowered.Blocks[0].Predecessors, Is.Empty);
+            Assert.That(lowered.Blocks[0].Successors, Is.EqualTo(new int[] { 1, 2 }));
+            Assert.That(lowered.Blocks[1].Predecessors, Is.EqualTo(new int[] { 0 }));
+            Assert.That(lowered.Blocks[1].Successors, Is.Empty);
+            Assert.That(lowered.Blocks[2].Predecessors, Is.EqualTo(new int[] { 0 }));
+            Assert.That(lowered.Blocks[2].Successors, Is.Empty);
         }
 
         [Test]
@@ -100,6 +107,34 @@ LB_2:
     Return 4 0 0 -> 0
 ";
             AssertDump(lowered, expected);
+        }
+
+        [Test]
+        public void Empty_block_is_properly_lowered()
+        {
+            const string source = @"
+; #0 void
+BB_0:
+    Return #0
+BB_1:
+";
+            var method = MethodAssembler.Assemble(source, "Test::Method");
+            var lowered = LoweringX64.Lower(method);
+
+            const string expected = @"
+; #0 void [?]
+; #1 void [rax]
+LB_0:
+    LoadInt 0 0 0 -> 1
+    Return 1 0 0 -> 0
+LB_1:
+";
+            AssertDump(lowered, expected);
+
+            Assert.That(lowered.Blocks[0].Predecessors, Is.Empty);
+            Assert.That(lowered.Blocks[1].Predecessors, Is.Empty);
+            Assert.That(lowered.Blocks[0].Successors, Is.Empty);
+            Assert.That(lowered.Blocks[1].Successors, Is.Empty);
         }
     }
 }

--- a/test/Cle.CodeGeneration.UnitTests/Lowering/CallLoweringX64Tests.cs
+++ b/test/Cle.CodeGeneration.UnitTests/Lowering/CallLoweringX64Tests.cs
@@ -24,10 +24,14 @@ BB_0:
 ; #0 void [?]
 ; #1 void [?]
 ; #2 void [?]
+; #3 void [rax]
+; #4 void [rax]
+; #5 void [rax]
 LB_0:
-    Call 0 0 100 -> 0
-    Call 1 0 100 -> 0
-    Return 0 0 0 -> 0
+    Call 0 0 100 -> 3
+    Call 1 0 100 -> 4
+    LoadInt 0 0 0 -> 5
+    Return 5 0 0 -> 0
 ";
             AssertDump(lowered, expected);
         }
@@ -64,7 +68,7 @@ LB_0:
     Move 6 0 0 -> 2
     Move 7 0 0 -> 3
     Move 0 0 0 -> 8
-    Return 0 0 0 -> 0
+    Return 8 0 0 -> 0
 ";
             AssertDump(lowered, expected);
         }
@@ -103,10 +107,10 @@ LB_0:
     Move 0 0 0 -> 6
     Move 2 0 0 -> 7
     Move 3 0 0 -> 8
-    Call 0 0 100 -> 0
+    Call 0 0 100 -> 9
     Move 9 0 0 -> 4
     Move 4 0 0 -> 10
-    Return 0 0 0 -> 0
+    Return 10 0 0 -> 0
 ";
             AssertDump(lowered, expected);
         }

--- a/test/Cle.CodeGeneration.UnitTests/Lowering/LoweringTestBase.cs
+++ b/test/Cle.CodeGeneration.UnitTests/Lowering/LoweringTestBase.cs
@@ -11,7 +11,7 @@ namespace Cle.CodeGeneration.UnitTests.Lowering
             where TRegister : struct, Enum
         {
             var dumpWriter = new StringWriter();
-            method.Dump(dumpWriter);
+            method.Dump(dumpWriter, true);
 
             Assert.That(dumpWriter.ToString().Replace("\r\n", "\n").Trim(), 
                 Is.EqualTo(expected.Replace("\r\n", "\n").Trim()));

--- a/test/Cle.CodeGeneration.UnitTests/PeepholeOptimizerTests.cs
+++ b/test/Cle.CodeGeneration.UnitTests/PeepholeOptimizerTests.cs
@@ -156,8 +156,10 @@ LB_0:
             OptimizeAndVerify(method, expected);
         }
 
-        [Test]
-        public void SetIfEqual_and_move_are_folded()
+        [TestCase(LowOp.SetIfEqual)]
+        [TestCase(LowOp.SetIfNotEqual)]
+        [TestCase(LowOp.SetIfGreater)]
+        public void SetIfX_and_move_are_folded(LowOp op)
         {
             var method = new LowMethod<X64Register>();
             method.Locals.Add(new LowLocal<X64Register>(SimpleType.Bool));
@@ -166,17 +168,17 @@ LB_0:
             {
                 Instructions =
                 {
-                    new LowInstruction(LowOp.SetIfEqual, 0, 0, 0, 0), // SetIfEqual #0
+                    new LowInstruction(op, 0, 0, 0, 0), // SetIfX #0
                     new LowInstruction(LowOp.Move, 1, 0, 0, 0), // Move #0 -> #1
                     new LowInstruction(LowOp.Return, 0, 1, 0, 0) // Return
                 }
             });
 
-            const string expected = @"
+            var expected = $@"
 ; #0 bool [?]
 ; #1 bool [rax]
 LB_0:
-    SetIfEqual 0 0 0 -> 1
+    {op} 0 0 0 -> 1
     Return 1 0 0 -> 0
 ";
             OptimizeAndVerify(method, expected);

--- a/test/Cle.CodeGeneration.UnitTests/PeepholeOptimizerTests.cs
+++ b/test/Cle.CodeGeneration.UnitTests/PeepholeOptimizerTests.cs
@@ -15,7 +15,7 @@ namespace Cle.CodeGeneration.UnitTests
             {
                 Instructions =
                 {
-                    new LowInstruction(LowOp.Return, 0, 0, 0, 0)
+                    new LowInstruction(LowOp.Nop, 0, 0, 0, 0)
                 }
             });
 
@@ -168,7 +168,7 @@ LB_0:
                 {
                     new LowInstruction(LowOp.SetIfEqual, 0, 0, 0, 0), // SetIfEqual #0
                     new LowInstruction(LowOp.Move, 1, 0, 0, 0), // Move #0 -> #1
-                    new LowInstruction(LowOp.Return, 0, 0, 0, 0) // Return
+                    new LowInstruction(LowOp.Return, 0, 1, 0, 0) // Return
                 }
             });
 
@@ -177,7 +177,7 @@ LB_0:
 ; #1 bool [rax]
 LB_0:
     SetIfEqual 0 0 0 -> 1
-    Return 0 0 0 -> 0
+    Return 1 0 0 -> 0
 ";
             OptimizeAndVerify(method, expected);
         }
@@ -317,7 +317,7 @@ LB_0:
                     new LowInstruction(LowOp.SetIfEqual, 3, 0, 0, 0), // SetIfZero #3 (negation, part 2)
                     new LowInstruction(LowOp.Test, 0, 3, 0, 0), // Test #3
                     new LowInstruction(LowOp.JumpIfNotEqual, 1, 0, 0, 0), // JumpIfNotEqual (not zero) LB_1
-                    new LowInstruction(LowOp.Return, 0, 0, 0, 0), // Return (#3)
+                    new LowInstruction(LowOp.Return, 0, 3, 0, 0), // Return (#3)
                 }
             });
 
@@ -330,7 +330,7 @@ LB_0:
     Compare 0 1 0 -> 0
     SetIfNotEqual 0 0 0 -> 3
     JumpIfNotEqual 0 0 0 -> 1
-    Return 0 0 0 -> 0
+    Return 3 0 0 -> 0
 ";
             OptimizeAndVerify(method, expected);
         }
@@ -353,7 +353,7 @@ LB_0:
                     new LowInstruction(LowOp.SetIfEqual, 3, 0, 0, 0), // SetIfZero #3 (negation, part 2)
                     new LowInstruction(LowOp.Test, 0, 3, 0, 0), // Test #3
                     new LowInstruction(LowOp.JumpIfNotEqual, 1, 0, 0, 0), // JumpIfNotEqual (not zero) LB_1
-                    new LowInstruction(LowOp.Return, 0, 0, 0, 0), // Return (#3)
+                    new LowInstruction(LowOp.Return, 0, 2, 0, 0), // Return #2
                 }
             });
 
@@ -366,7 +366,7 @@ LB_0:
     Compare 0 1 0 -> 0
     SetIfEqual 0 0 0 -> 2
     JumpIfNotEqual 0 0 0 -> 1
-    Return 0 0 0 -> 0
+    Return 2 0 0 -> 0
 ";
             OptimizeAndVerify(method, expected);
         }

--- a/test/Cle.CodeGeneration.UnitTests/PeepholeOptimizerTests.cs
+++ b/test/Cle.CodeGeneration.UnitTests/PeepholeOptimizerTests.cs
@@ -99,12 +99,10 @@ LB_0:
         public void Unnecessary_temporary_moves_are_folded()
         {
             var method = new LowMethod<X64Register>();
-            method.Locals.Add(new LowLocal<X64Register>(SimpleType.Int32)
-                { Location = new StorageLocation<X64Register>(X64Register.Rax) });
+            method.Locals.Add(new LowLocal<X64Register>(SimpleType.Int32, X64Register.Rax));
             method.Locals.Add(new LowLocal<X64Register>(SimpleType.Int32));
             method.Locals.Add(new LowLocal<X64Register>(SimpleType.Int32));
-            method.Locals.Add(new LowLocal<X64Register>(SimpleType.Int32)
-                { Location = new StorageLocation<X64Register>(X64Register.Rax) });
+            method.Locals.Add(new LowLocal<X64Register>(SimpleType.Int32, X64Register.Rax));
             method.Blocks.Add(new LowBlock
             {
                 Instructions =
@@ -130,12 +128,10 @@ LB_0:
         public void Necessary_temporary_move_is_not_folded()
         {
             var method = new LowMethod<X64Register>();
-            method.Locals.Add(new LowLocal<X64Register>(SimpleType.Int32)
-                { Location = new StorageLocation<X64Register>(X64Register.Rax) });
+            method.Locals.Add(new LowLocal<X64Register>(SimpleType.Int32, X64Register.Rax));
             method.Locals.Add(new LowLocal<X64Register>(SimpleType.Int32));
             method.Locals.Add(new LowLocal<X64Register>(SimpleType.Int32));
-            method.Locals.Add(new LowLocal<X64Register>(SimpleType.Int32)
-                { Location = new StorageLocation<X64Register>(X64Register.Rax) });
+            method.Locals.Add(new LowLocal<X64Register>(SimpleType.Int32, X64Register.Rax));
             method.Blocks.Add(new LowBlock
             {
                 Instructions =
@@ -165,8 +161,7 @@ LB_0:
         {
             var method = new LowMethod<X64Register>();
             method.Locals.Add(new LowLocal<X64Register>(SimpleType.Bool));
-            method.Locals.Add(new LowLocal<X64Register>(SimpleType.Bool)
-                { Location = new StorageLocation<X64Register>(X64Register.Rax) });
+            method.Locals.Add(new LowLocal<X64Register>(SimpleType.Bool, X64Register.Rax));
             method.Blocks.Add(new LowBlock
             {
                 Instructions =
@@ -191,8 +186,7 @@ LB_0:
         public void SetIfEqual_and_move_are_not_folded_if_original_local_is_used()
         {
             var method = new LowMethod<X64Register>();
-            method.Locals.Add(new LowLocal<X64Register>(SimpleType.Bool)
-                { Location = new StorageLocation<X64Register>(X64Register.Rax) });
+            method.Locals.Add(new LowLocal<X64Register>(SimpleType.Bool, X64Register.Rax));
             method.Locals.Add(new LowLocal<X64Register>(SimpleType.Bool));
             method.Blocks.Add(new LowBlock
             {
@@ -279,8 +273,7 @@ LB_0:
             var method = new LowMethod<X64Register>();
             method.Locals.Add(new LowLocal<X64Register>(SimpleType.Int32));
             method.Locals.Add(new LowLocal<X64Register>(SimpleType.Int32));
-            method.Locals.Add(new LowLocal<X64Register>(SimpleType.Bool)
-                { Location = new StorageLocation<X64Register>(X64Register.Rax) });
+            method.Locals.Add(new LowLocal<X64Register>(SimpleType.Bool, X64Register.Rax));
             method.Blocks.Add(new LowBlock
             {
                 Instructions =
@@ -313,8 +306,7 @@ LB_0:
             method.Locals.Add(new LowLocal<X64Register>(SimpleType.Int32));
             method.Locals.Add(new LowLocal<X64Register>(SimpleType.Int32));
             method.Locals.Add(new LowLocal<X64Register>(SimpleType.Bool));
-            method.Locals.Add(new LowLocal<X64Register>(SimpleType.Bool)
-                { Location = new StorageLocation<X64Register>(X64Register.Rax) });
+            method.Locals.Add(new LowLocal<X64Register>(SimpleType.Bool, X64Register.Rax));
             method.Blocks.Add(new LowBlock
             {
                 Instructions =
@@ -349,8 +341,7 @@ LB_0:
             var method = new LowMethod<X64Register>();
             method.Locals.Add(new LowLocal<X64Register>(SimpleType.Int32));
             method.Locals.Add(new LowLocal<X64Register>(SimpleType.Int32));
-            method.Locals.Add(new LowLocal<X64Register>(SimpleType.Bool)
-                { Location = new StorageLocation<X64Register>(X64Register.Rax) });
+            method.Locals.Add(new LowLocal<X64Register>(SimpleType.Bool, X64Register.Rax));
             method.Locals.Add(new LowLocal<X64Register>(SimpleType.Bool));
             method.Blocks.Add(new LowBlock
             {
@@ -385,7 +376,7 @@ LB_0:
             PeepholeOptimizer<X64Register>.Optimize(method);
 
             var dumpWriter = new StringWriter();
-            method.Dump(dumpWriter);
+            method.Dump(dumpWriter, true);
 
             Assert.That(dumpWriter.ToString().Replace("\r\n", "\n").Trim(),
                 Is.EqualTo(expected.Replace("\r\n", "\n").Trim()));
@@ -394,7 +385,7 @@ LB_0:
         private static void OptimizeAndVerifyUnchanged(LowMethod<X64Register> method)
         {
             var expected = new StringWriter();
-            method.Dump(expected);
+            method.Dump(expected, true);
 
             OptimizeAndVerify(method, expected.ToString());
         }

--- a/test/Cle.CodeGeneration.UnitTests/RegisterAllocation/X64RegisterAllocatorTests.cs
+++ b/test/Cle.CodeGeneration.UnitTests/RegisterAllocation/X64RegisterAllocatorTests.cs
@@ -15,6 +15,7 @@ namespace Cle.CodeGeneration.UnitTests.RegisterAllocation
             var method = new LowMethod<X64Register>();
             method.Locals.Add(new LowLocal<X64Register>(SimpleType.Bool));
             method.Locals.Add(new LowLocal<X64Register>(SimpleType.Bool));
+            method.Locals.Add(new LowLocal<X64Register>(SimpleType.Void, X64Register.Rax));
             method.Blocks.Add(new LowBlock
             {
                 Instructions =
@@ -22,7 +23,8 @@ namespace Cle.CodeGeneration.UnitTests.RegisterAllocation
                     new LowInstruction(LowOp.LoadInt, 0, 0, 0, 1), // Load 1 -> #0
                     new LowInstruction(LowOp.LoadInt, 1, 0, 0, 1), // Load 1 -> #1
                     new LowInstruction(LowOp.Compare, 0, 0, 1, 0), // Compare #0, #1
-                    new LowInstruction(LowOp.Return, 0, 0, 0, 0)
+                    new LowInstruction(LowOp.LoadInt, 2, 0, 0, 0), // Initialize void return
+                    new LowInstruction(LowOp.Return, 2, 0, 0, 0)
                 }
             });
 
@@ -30,10 +32,12 @@ namespace Cle.CodeGeneration.UnitTests.RegisterAllocation
 
             Assert.That(allocationMap.Get(0).localIndex, Is.EqualTo(0));
             Assert.That(allocationMap.Get(1).localIndex, Is.EqualTo(1));
+            Assert.That(allocationMap.Get(2).localIndex, Is.EqualTo(2));
 
             Assert.That(allocationMap.Get(0).location.IsSet, Is.True);
             Assert.That(allocationMap.Get(1).location.IsSet, Is.True);
             Assert.That(allocationMap.Get(0).location, Is.Not.EqualTo(allocationMap.Get(1).location));
+            Assert.That(allocationMap.Get(2).location.Register, Is.EqualTo(X64Register.Rax));
         }
 
         [Test]
@@ -42,6 +46,7 @@ namespace Cle.CodeGeneration.UnitTests.RegisterAllocation
             var method = new LowMethod<X64Register>();
             method.Locals.Add(new LowLocal<X64Register>(SimpleType.Bool));
             method.Locals.Add(new LowLocal<X64Register>(SimpleType.Bool));
+            method.Locals.Add(new LowLocal<X64Register>(SimpleType.Void, X64Register.Rax));
             method.Blocks.Add(new LowBlock
             {
                 Instructions =
@@ -49,7 +54,8 @@ namespace Cle.CodeGeneration.UnitTests.RegisterAllocation
                     new LowInstruction(LowOp.LoadInt, 0, 0, 0, 1), // Load 1 -> #0
                     new LowInstruction(LowOp.Move, 1, 0, 0, 0), // Move #0 -> #1
                     new LowInstruction(LowOp.Test, 0, 1, 0, 0), // Test #1
-                    new LowInstruction(LowOp.Return, 0, 0, 0, 0)
+                    new LowInstruction(LowOp.LoadInt, 2, 0, 0, 0), // Initialize void return
+                    new LowInstruction(LowOp.Return, 0, 2, 0, 0)
                 }
             });
 
@@ -57,6 +63,7 @@ namespace Cle.CodeGeneration.UnitTests.RegisterAllocation
 
             Assert.That(allocationMap.Get(0).localIndex, Is.EqualTo(0));
             Assert.That(allocationMap.Get(1).localIndex, Is.EqualTo(1));
+            Assert.That(allocationMap.Get(2).localIndex, Is.EqualTo(2));
 
             Assert.That(allocationMap.Get(0).location.IsSet, Is.True);
             Assert.That(allocationMap.Get(1).location.IsSet, Is.True);
@@ -77,7 +84,7 @@ namespace Cle.CodeGeneration.UnitTests.RegisterAllocation
                     new LowInstruction(LowOp.LoadInt, 0, 0, 0, 1), // Load 1 -> #0
                     new LowInstruction(LowOp.Move, 1, 0, 0, 0), // Move #0 -> #1
                     new LowInstruction(LowOp.Compare, 0, 1, 0, 0), // Compare #1, #0
-                    new LowInstruction(LowOp.Return, 0, 0, 0, 0)
+                    new LowInstruction(LowOp.Return, 0, 0, 0, 0) // Return #0
                 }
             });
 
@@ -172,6 +179,7 @@ namespace Cle.CodeGeneration.UnitTests.RegisterAllocation
             method.Locals.Add(new LowLocal<X64Register>(SimpleType.Bool));
             method.Locals.Add(new LowLocal<X64Register>(SimpleType.Bool));
             method.Locals.Add(new LowLocal<X64Register>(SimpleType.Bool));
+            method.Locals.Add(new LowLocal<X64Register>(SimpleType.Void, X64Register.Rax));
             method.Blocks.Add(new LowBlock
             {
                 Instructions =
@@ -182,14 +190,14 @@ namespace Cle.CodeGeneration.UnitTests.RegisterAllocation
                     new LowInstruction(LowOp.LoadInt, 3, 0, 0, 1), // Load 1 -> #3
                     new LowInstruction(LowOp.LoadInt, 4, 0, 0, 1), // Load 1 -> #4
 
-                    new LowInstruction(LowOp.Call, 0, 0, 0, 1234), // Call - this trashes rax, rcx, rdx, r8 and r9
+                    new LowInstruction(LowOp.Call, 5, 0, 0, 1234), // Call - this trashes rax, rcx, rdx, r8 and r9
 
                     new LowInstruction(LowOp.Test, 0, 0, 0, 0), // Test #0
                     new LowInstruction(LowOp.Test, 0, 1, 0, 0), // Test #1
                     new LowInstruction(LowOp.Test, 0, 2, 0, 0), // Test #2
                     new LowInstruction(LowOp.Test, 0, 3, 0, 0), // Test #3
                     new LowInstruction(LowOp.Test, 0, 4, 0, 0), // Test #4
-                    new LowInstruction(LowOp.Return, 0, 0, 0, 0)
+                    new LowInstruction(LowOp.Return, 5, 0, 0, 0)
                 }
             });
 
@@ -202,6 +210,12 @@ namespace Cle.CodeGeneration.UnitTests.RegisterAllocation
 
                 if (localIndex == -1)
                     continue;
+
+                if (localIndex == 5)
+                {
+                    Assert.That(location.Register, Is.EqualTo(X64Register.Rax));
+                    continue;
+                }
 
                 Assert.That(location.IsSet, Is.True);
                 Assert.That(location.Register, Is.Not.EqualTo(X64Register.Rax));
@@ -224,6 +238,7 @@ namespace Cle.CodeGeneration.UnitTests.RegisterAllocation
             method.Locals.Add(new LowLocal<X64Register>(SimpleType.Int32));
             method.Locals.Add(new LowLocal<X64Register>(SimpleType.Int32));
             method.Locals.Add(new LowLocal<X64Register>(SimpleType.Int32));
+            method.Locals.Add(new LowLocal<X64Register>(SimpleType.Int32, X64Register.Rax));
             method.Blocks.Add(new LowBlock
             {
                 Instructions =
@@ -234,8 +249,8 @@ namespace Cle.CodeGeneration.UnitTests.RegisterAllocation
                     new LowInstruction(LowOp.IntegerSubtract, 2, 0, 1, 0), // Subtract #0 - #1 -> #2
 
                     new LowInstruction(LowOp.Test, 0, 0, 0, 0), // Use #0
-                    new LowInstruction(LowOp.Test, 0, 2, 0, 0), // Use #2
-                    new LowInstruction(LowOp.Return, 0, 0, 0, 0)
+                    new LowInstruction(LowOp.Move, 3, 2, 0, 0), // Use #2
+                    new LowInstruction(LowOp.Return, 3, 0, 0, 0)
                 }
             });
 

--- a/test/Cle.CodeGeneration.UnitTests/RegisterAllocation/X64RegisterAllocatorTests.cs
+++ b/test/Cle.CodeGeneration.UnitTests/RegisterAllocation/X64RegisterAllocatorTests.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using Cle.CodeGeneration.Lir;
 using Cle.CodeGeneration.RegisterAllocation;
 using Cle.Common.TypeSystem;
@@ -24,11 +27,21 @@ namespace Cle.CodeGeneration.UnitTests.RegisterAllocation
                     new LowInstruction(LowOp.LoadInt, 1, 0, 0, 1), // Load 1 -> #1
                     new LowInstruction(LowOp.Compare, 0, 0, 1, 0), // Compare #0, #1
                     new LowInstruction(LowOp.LoadInt, 2, 0, 0, 0), // Initialize void return
-                    new LowInstruction(LowOp.Return, 2, 0, 0, 0)
-                }
+                    new LowInstruction(LowOp.Return, 0, 2, 0, 0)
+                },
+                Predecessors = Array.Empty<int>(),
+                Successors = Array.Empty<int>()
             });
 
             var (rewritten, allocationMap) = X64RegisterAllocator.Allocate(method);
+
+            AssertDump(rewritten, @"
+LB_0:
+    LoadInt 0 0 1 -> 0
+    LoadInt 0 0 1 -> 1
+    Compare 0 1 0 -> 0
+    LoadInt 0 0 0 -> 2
+    Return 2 0 0 -> 0");
 
             Assert.That(allocationMap.Get(0).localIndex, Is.EqualTo(0));
             Assert.That(allocationMap.Get(1).localIndex, Is.EqualTo(1));
@@ -56,10 +69,20 @@ namespace Cle.CodeGeneration.UnitTests.RegisterAllocation
                     new LowInstruction(LowOp.Test, 0, 1, 0, 0), // Test #1
                     new LowInstruction(LowOp.LoadInt, 2, 0, 0, 0), // Initialize void return
                     new LowInstruction(LowOp.Return, 0, 2, 0, 0)
-                }
+                },
+                Predecessors = Array.Empty<int>(),
+                Successors = Array.Empty<int>()
             });
 
             var (rewritten, allocationMap) = X64RegisterAllocator.Allocate(method);
+
+            AssertDump(rewritten, @"
+LB_0:
+    LoadInt 0 0 1 -> 0
+    Move 0 0 0 -> 1
+    Test 1 0 0 -> 0
+    LoadInt 0 0 0 -> 2
+    Return 2 0 0 -> 0");
 
             Assert.That(allocationMap.Get(0).localIndex, Is.EqualTo(0));
             Assert.That(allocationMap.Get(1).localIndex, Is.EqualTo(1));
@@ -85,10 +108,19 @@ namespace Cle.CodeGeneration.UnitTests.RegisterAllocation
                     new LowInstruction(LowOp.Move, 1, 0, 0, 0), // Move #0 -> #1
                     new LowInstruction(LowOp.Compare, 0, 1, 0, 0), // Compare #1, #0
                     new LowInstruction(LowOp.Return, 0, 0, 0, 0) // Return #0
-                }
+                },
+                Predecessors = Array.Empty<int>(),
+                Successors = Array.Empty<int>()
             });
 
             var (rewritten, allocationMap) = X64RegisterAllocator.Allocate(method);
+
+            AssertDump(rewritten, @"
+LB_0:
+    LoadInt 0 0 1 -> 0
+    Move 0 0 0 -> 1
+    Compare 1 0 0 -> 0
+    Return 0 0 0 -> 0");
 
             Assert.That(allocationMap.Get(0).localIndex, Is.EqualTo(0));
             Assert.That(allocationMap.Get(1).localIndex, Is.EqualTo(1));
@@ -109,14 +141,23 @@ namespace Cle.CodeGeneration.UnitTests.RegisterAllocation
             {
                 Instructions =
                 {
-                    new LowInstruction(LowOp.LoadInt, 0, 0, 0, 1), // Load 1 -> #1
+                    new LowInstruction(LowOp.LoadInt, 1, 0, 0, 1), // Load 1 -> #1
                     new LowInstruction(LowOp.IntegerAdd, 2, 0, 1, 0), // Add #0, #1 -> #2
                     new LowInstruction(LowOp.Jump, 0, 0, 0, 0)
                 },
-                Phis = new[] { new Phi(0, ImmutableList<int>.Empty.Add(2)) }
+                Phis = new[] { new Phi(0, ImmutableList<int>.Empty.Add(2)) },
+                Predecessors = new int[] { 0 },
+                Successors = new int[] { 0 }
             });
 
             var (rewritten, allocationMap) = X64RegisterAllocator.Allocate(method);
+
+            // #0 and #2 have the same register, therefore there is no move instruction
+            AssertDump(rewritten, @"
+LB_0:
+    LoadInt 0 0 1 -> 1
+    IntegerAdd 0 1 0 -> 2
+    Jump 0 0 0 -> 0");
 
             Assert.That(allocationMap.Get(0).localIndex, Is.EqualTo(0));
             Assert.That(allocationMap.Get(1).localIndex, Is.EqualTo(1));
@@ -128,46 +169,96 @@ namespace Cle.CodeGeneration.UnitTests.RegisterAllocation
         }
 
         [Test]
-        public void Phi_referencing_another_phi()
+        public void Complex_phi_chain_is_not_allocated_the_same_register()
         {
+            // void Swap() {
+            //   int32 a = 10;
+            //   int32 b = 11;
+            //   while (a < b) {
+            //      int32 temp = a;
+            //      a = b;
+            //      b = temp;
+            //   }
+            // }
             var method = new LowMethod<X64Register>();
             method.Locals.Add(new LowLocal<X64Register>(SimpleType.Int32));
             method.Locals.Add(new LowLocal<X64Register>(SimpleType.Int32));
             method.Locals.Add(new LowLocal<X64Register>(SimpleType.Int32));
             method.Locals.Add(new LowLocal<X64Register>(SimpleType.Int32));
-            method.Locals.Add(new LowLocal<X64Register>(SimpleType.Int32));
+            method.Locals.Add(new LowLocal<X64Register>(SimpleType.Void, X64Register.Rax));
+
             method.Blocks.Add(new LowBlock
             {
                 Instructions =
                 {
-                    new LowInstruction(LowOp.LoadInt, 0, 0, 0, 1), // Load 1 -> #2
-                    new LowInstruction(LowOp.IntegerAdd, 3, 1, 2, 0), // Add #1, #2 -> #3
-                    new LowInstruction(LowOp.Jump, 0, 0, 0, 0)
+                    new LowInstruction(LowOp.LoadInt, 0, 0, 0, 10), // Load 10 -> #0
+                    new LowInstruction(LowOp.LoadInt, 1, 0, 0, 11), // Load 11 -> #1
+                    new LowInstruction(LowOp.Jump, 1, 0, 0, 0)
                 },
-                Phis = new[] { new Phi(1, ImmutableList<int>.Empty.Add(3)) }
+                Predecessors = Array.Empty<int>(),
+                Successors = new[] { 1 },
+            });
+            method.Blocks.Add(new LowBlock
+            {
+                Phis = new List<Phi>()
+                {
+                    new Phi(2, new[] { 0, 3 }.ToImmutableList()),
+                    new Phi(3, new[] { 1, 2 }.ToImmutableList())
+                },
+                Instructions =
+                {
+                    new LowInstruction(LowOp.Compare, 0, 2, 3, 0), // Compare #2, #3
+                    new LowInstruction(LowOp.JumpIfLess, 3, 0, 0, 0), // JumpIfLess LB_3
+                    new LowInstruction(LowOp.Jump, 2, 0, 0, 0), // Jump LB_2
+                },
+                Predecessors = new[] { 0, 2 },
+                Successors = new[] { 3, 2 },
             });
             method.Blocks.Add(new LowBlock
             {
                 Instructions =
                 {
-                    new LowInstruction(LowOp.Return, 0, 0, 0, 0)
+                    new LowInstruction(LowOp.Jump, 1, 0, 0, 0) // Jump LB_1
                 },
-                Phis = new[] { new Phi(4, ImmutableList<int>.Empty.Add(0).Add(1)) }
+                Predecessors = new[] { 1 },
+                Successors = new[] { 1 },
+            });
+            method.Blocks.Add(new LowBlock
+            {
+                Instructions =
+                {
+                    new LowInstruction(LowOp.LoadInt, 4, 0, 0, 0), // Void return
+                    new LowInstruction(LowOp.Return, 0, 4, 0, 0) // Return
+                },
+                Predecessors = new[] { 1 },
+                Successors = Array.Empty<int>(),
             });
 
-            var (rewritten, allocationMap) = X64RegisterAllocator.Allocate(method);
+            // Act
+            var (converted, map) = X64RegisterAllocator.Allocate(method);
 
-            for (var i = 0; i < 5; i++)
-            {
-                Assert.That(allocationMap.Get(i).localIndex, Is.EqualTo(i));
-                Assert.That(allocationMap.Get(i).location.IsSet, Is.True);
-            }
+            // Assert
+            AssertDump(converted, @"
+LB_0:
+    LoadInt 0 0 10 -> 0
+    LoadInt 0 0 11 -> 1
+    Jump 0 0 0 -> 1
+LB_1:
+    Compare 2 3 0 -> 0
+    JumpIfLess 0 0 0 -> 3
+    Jump 0 0 0 -> 2
+LB_2:
+    Swap 3 2 0 -> 0
+    Jump 0 0 0 -> 1
+LB_3:
+    LoadInt 0 0 0 -> 4
+    Return 4 0 0 -> 0");
 
-            Assert.That(allocationMap.Get(0).location, Is.EqualTo(allocationMap.Get(1).location));
-            Assert.That(allocationMap.Get(0).location, Is.EqualTo(allocationMap.Get(3).location));
-            Assert.That(allocationMap.Get(0).location, Is.EqualTo(allocationMap.Get(4).location));
-
-            Assert.That(allocationMap.Get(0).location, Is.Not.EqualTo(allocationMap.Get(2).location));
+            // The Phi destinations must have intersecting intervals and therefore different registers,
+            // while the values from the initial block should not need any copies
+            Assert.That(map.Get(3).location, Is.Not.EqualTo(map.Get(4).location));
+            Assert.That(map.Get(0).location, Is.EqualTo(map.Get(2).location));
+            Assert.That(map.Get(1).location, Is.EqualTo(map.Get(3).location));
         }
 
         [Test]
@@ -198,10 +289,12 @@ namespace Cle.CodeGeneration.UnitTests.RegisterAllocation
                     new LowInstruction(LowOp.Test, 0, 3, 0, 0), // Test #3
                     new LowInstruction(LowOp.Test, 0, 4, 0, 0), // Test #4
                     new LowInstruction(LowOp.Return, 5, 0, 0, 0)
-                }
+                },
+                Predecessors = Array.Empty<int>(),
+                Successors = Array.Empty<int>()
             });
 
-            var (rewritten, allocationMap) = X64RegisterAllocator.Allocate(method);
+            var (_, allocationMap) = X64RegisterAllocator.Allocate(method);
 
             // No local variable should be assigned to a blocked register
             for (var i = 0; i < allocationMap.IntervalCount; i++)
@@ -250,17 +343,41 @@ namespace Cle.CodeGeneration.UnitTests.RegisterAllocation
 
                     new LowInstruction(LowOp.Test, 0, 0, 0, 0), // Use #0
                     new LowInstruction(LowOp.Move, 3, 2, 0, 0), // Use #2
-                    new LowInstruction(LowOp.Return, 3, 0, 0, 0)
-                }
+                    new LowInstruction(LowOp.Return, 0, 3, 0, 0)
+                },
+                Predecessors = Array.Empty<int>(),
+                Successors = Array.Empty<int>()
             });
 
             var (rewritten, allocationMap) = X64RegisterAllocator.Allocate(method);
+
+            AssertDump(rewritten, @"
+LB_0:
+    LoadInt 0 0 1 -> 0
+    LoadInt 0 0 1 -> 1
+    IntegerSubtract 0 1 0 -> 2
+    Test 0 0 0 -> 0
+    Move 2 0 0 -> 3
+    Return 3 0 0 -> 0");
+
+            Assert.That(allocationMap.Get(0).localIndex, Is.EqualTo(0));
+            Assert.That(allocationMap.Get(1).localIndex, Is.EqualTo(1));
+            Assert.That(allocationMap.Get(2).localIndex, Is.EqualTo(2));
 
             // It would be tempting to assign #1 and #2 the same register, but that
             // is not good for x64: we would have to emit "mov r1, r0; sub r1, r1" where
             // local #1 is stored in r1 but local #2 lives there up until the last instruction.
             Assert.That(allocationMap.Get(1).location.Register,
                 Is.Not.EqualTo(allocationMap.Get(2).location.Register));
+        }
+
+        private static void AssertDump(LowMethod<X64Register> method, string expected)
+        {
+            var dumpWriter = new StringWriter();
+            method.Dump(dumpWriter, false);
+
+            Assert.That(dumpWriter.ToString().Replace("\r\n", "\n").Trim(),
+                Is.EqualTo(expected.Replace("\r\n", "\n").Trim()));
         }
     }
 }

--- a/test/Cle.CodeGeneration.UnitTests/X64CodeGenerator/BranchTests.cs
+++ b/test/Cle.CodeGeneration.UnitTests/X64CodeGenerator/BranchTests.cs
@@ -217,11 +217,16 @@ BB_0:
 
 BB_1:
     Load 1 -> #2
+    ==> BB_3
 
 BB_2:
+
+BB_3:
     PHI (#0, #2) -> #3
     Return #3";
 
+            // TODO: The "jmp LB_3" should be elided since the real jump amount is zero
+            //       This is not caught by the current heuristic that only compares the block indices
             const string expected = @"
 ; Test::Method
 LB_0:
@@ -232,7 +237,9 @@ LB_0:
     jmp LB_2
 LB_1:
     mov eax, 1h
+    jmp LB_3
 LB_2:
+LB_3:
     ret
 ";
             EmitAndAssertDisassembly(source, expected);

--- a/test/Cle.CodeGeneration.UnitTests/X64CodeGenerator/BranchTests.cs
+++ b/test/Cle.CodeGeneration.UnitTests/X64CodeGenerator/BranchTests.cs
@@ -39,9 +39,9 @@ BB_2:
             var expected = $@"
 ; Test::Method
 LB_0:
-    mov eax, 2Ah
-    mov ecx, 64h
-    cmp eax, ecx
+    mov ecx, 2Ah
+    mov edx, 64h
+    cmp ecx, edx
     {expectedConditionalJump} LB_1
     jmp LB_2
 LB_1:
@@ -91,9 +91,9 @@ BB_2:
             var expected = $@"
 ; Test::Method
 LB_0:
-    mov eax, 2Ah
-    mov ecx, 64h
-    cmp eax, ecx
+    mov ecx, 2Ah
+    mov edx, 64h
+    cmp ecx, edx
     {expectedConditionalJump} LB_1
     jmp LB_2
 LB_1:
@@ -135,8 +135,8 @@ BB_2:
             const string expected = @"
 ; Test::Method
 LB_0:
-    mov eax, 1h
-    test rax, rax
+    mov ecx, 1h
+    test rcx, rcx
     jne LB_1
     jmp LB_2
 LB_1:
@@ -180,8 +180,8 @@ BB_2:
             const string expected = @"
 ; Test::Method
 LB_0:
-    mov eax, 1h
-    test rax, rax
+    mov ecx, 1h
+    test rcx, rcx
     je LB_1
     jmp LB_2
 LB_1:
@@ -230,16 +230,17 @@ BB_3:
             const string expected = @"
 ; Test::Method
 LB_0:
-    mov eax, 0h
-    mov ecx, 1h
-    test rcx, rcx
+    mov ecx, 0h
+    mov edx, 1h
+    test rdx, rdx
     jne LB_1
     jmp LB_2
 LB_1:
-    mov eax, 1h
+    mov ecx, 1h
     jmp LB_3
 LB_2:
 LB_3:
+    mov eax, ecx
     ret
 ";
             EmitAndAssertDisassembly(source, expected);

--- a/test/Cle.CodeGeneration.UnitTests/X64CodeGenerator/CallTests.cs
+++ b/test/Cle.CodeGeneration.UnitTests/X64CodeGenerator/CallTests.cs
@@ -44,13 +44,11 @@ BB_0:
     Call Test::DoSomething(#2, #3) -> #0
     Return #1";
             
-            // TODO: There should be no register shuffling (LSRA should have a register hint)
             const string expected = @"
 ; Test::Method
 LB_0:
-    mov eax, 1h
+    mov ecx, 1h
     mov edx, 1h
-    mov ecx, eax
     call Test::DoSomething
     mov eax, 0h
     ret

--- a/test/Cle.CodeGeneration.UnitTests/X64CodeGenerator/CallTests.cs
+++ b/test/Cle.CodeGeneration.UnitTests/X64CodeGenerator/CallTests.cs
@@ -17,10 +17,12 @@ BB_0:
     Return #1";
 
             // TODO: A good peephole optimizer would convert the call to a jmp
+            // TODO: The return value could be left uninitialized (currently, LSRA wants SSA form)
             const string expected = @"
 ; Test::Method
 LB_0:
     call Test::DoNothing
+    mov eax, 0h
     ret
 ";
             EmitAndAssertDisassembly(source, expected);
@@ -50,6 +52,7 @@ LB_0:
     mov edx, 1h
     mov ecx, eax
     call Test::DoSomething
+    mov eax, 0h
     ret
 ";
             EmitAndAssertDisassembly(source, expected);

--- a/test/Cle.CodeGeneration.UnitTests/X64CodeGenerator/LoggingTests.cs
+++ b/test/Cle.CodeGeneration.UnitTests/X64CodeGenerator/LoggingTests.cs
@@ -25,7 +25,8 @@ BB_0:
                 Assert.That(dumpString, Contains.Substring("Return 0 0 0 -> 0"));
 
                 // Locals
-                Assert.That(dumpString, Contains.Substring("; #0 int32 [rax]"));
+                // #0 has no forced position, the others have
+                Assert.That(dumpString, Contains.Substring("; #0 int32 [?]"));
                 Assert.That(dumpString, Contains.Substring("; #1 int32 [rcx]"));
                 Assert.That(dumpString, Contains.Substring("; #2 int32 [rax]"));
             }

--- a/test/Cle.CodeGeneration.UnitTests/X64CodeGenerator/LoggingTests.cs
+++ b/test/Cle.CodeGeneration.UnitTests/X64CodeGenerator/LoggingTests.cs
@@ -22,7 +22,7 @@ BB_0:
                 var dumpString = dumpWriter.ToString();
 
                 // Dumped LIR
-                Assert.That(dumpString, Contains.Substring("Return 0 0 0 -> 0"));
+                Assert.That(dumpString, Contains.Substring("Return 2 0 0 -> 0"));
 
                 // Locals
                 // #0 has no forced position, the others have

--- a/test/Cle.CodeGeneration.UnitTests/X64CodeGenerator/VariableTests.cs
+++ b/test/Cle.CodeGeneration.UnitTests/X64CodeGenerator/VariableTests.cs
@@ -44,9 +44,9 @@ BB_0:
             var expected = $@"
 ; Test::Method
 LB_0:
-    mov eax, 2Ah
-    mov ecx, 64h
-    cmp eax, ecx
+    mov ecx, 2Ah
+    mov edx, 64h
+    cmp ecx, edx
     {expectedLowOp} al
     movzx rax, al
     ret
@@ -77,9 +77,9 @@ BB_0:
             var expected = $@"
 ; Test::Method
 LB_0:
-    mov eax, 2Ah
-    mov ecx, 64h
-    cmp eax, ecx
+    mov ecx, 2Ah
+    mov edx, 64h
+    cmp ecx, edx
     {expectedLowOp} al
     movzx rax, al
     ret
@@ -115,13 +115,14 @@ BB_0:
             var expected = $@"
 ; Test::Method
 LB_0:
-    mov eax, 2Ah
-    mov ecx, 64h
-    mov edx, eax
-    {expectedAsmOp} edx, ecx
-    {expectedAsmOp} edx, eax
+    mov ecx, 2Ah
+    mov edx, 64h
+    mov eax, ecx
     {expectedAsmOp} eax, edx
     {expectedAsmOp} eax, ecx
+    {expectedAsmOp} ecx, eax
+    {expectedAsmOp} ecx, edx
+    mov eax, ecx
     ret
 ";
             EmitAndAssertDisassembly(source, expected);
@@ -155,14 +156,15 @@ BB_0:
             var expected = $@"
 ; Test::Method
 LB_0:
-    mov eax, 2Ah
-    mov ecx, 64h
-    mov edx, eax
-    {expectedAsmOp} edx, ecx
-    mov r8d, eax
-    {expectedAsmOp} r8d, edx
-    {expectedAsmOp} eax, r8d
-    {expectedAsmOp} eax, ecx
+    mov ecx, 2Ah
+    mov edx, 64h
+    mov eax, ecx
+    {expectedAsmOp} eax, edx
+    mov r8d, ecx
+    {expectedAsmOp} r8d, eax
+    {expectedAsmOp} ecx, r8d
+    {expectedAsmOp} ecx, edx
+    mov eax, ecx
     ret
 ";
             EmitAndAssertDisassembly(source, expected);

--- a/test/Cle.CodeGeneration.UnitTests/X64EmitterTests.cs
+++ b/test/Cle.CodeGeneration.UnitTests/X64EmitterTests.cs
@@ -147,6 +147,17 @@ namespace Cle.CodeGeneration.UnitTests
         }
 
         [Test]
+        public void EmitExchange_swaps_new_and_basic_register()
+        {
+            GetEmitter(out var stream, out var disassembly).EmitExchange(
+                new StorageLocation<X64Register>(X64Register.R13),
+                new StorageLocation<X64Register>(X64Register.Rcx));
+
+            CollectionAssert.AreEqual(new byte[] { 0x4C, 0x87, 0xE9 }, stream.ToArray());
+            Assert.That(disassembly.ToString().Trim(), Is.EqualTo("xchg r13, rcx"));
+        }
+
+        [Test]
         public void EmitSetcc_emits_setne_to_basic_register()
         {
             GetEmitter(out var stream, out var disassembly).EmitSetcc(

--- a/test/Cle.IntegrationTests/CodeGenBringUpTests.cs
+++ b/test/Cle.IntegrationTests/CodeGenBringUpTests.cs
@@ -12,11 +12,14 @@ namespace Cle.IntegrationTests
         [TestCase("FunctionCallWithTwoInt32Params", 15)]
         [TestCase("FunctionCallWithVoid", 100)]
         [TestCase("IntEquality", 100)]
+        [TestCase("LargeIf", 32)]
         [TestCase("ReturnInt", 42)]
         [TestCase("ReturnParameter", 100)]
         [TestCase("SimpleForwardPhi", 50)]
         [TestCase("SimpleWhileLoop", 45)]
         [TestCase("SimpleWhileLoop2", 36)]
+        [TestCase("SwapAndReturnSmaller1", 10)]
+        [TestCase("SwapAndReturnSmaller2", 15)]
         public void CodeGenBringUp(string testCase, int expectedReturnCode)
         {
             new TestRunner(Path.Combine(BaseDirectory, testCase))

--- a/test/Cle.IntegrationTests/FunctionalTests.cs
+++ b/test/Cle.IntegrationTests/FunctionalTests.cs
@@ -8,6 +8,7 @@ namespace Cle.IntegrationTests
         private const string BaseDirectory = "TestCases/Functional";
         private const int ExecutionTimeOutMilliseconds = 1000;
 
+        [TestCase("IterativeFibonacci", 55)]
         [TestCase("RecursiveFibonacci", 55)]
         public void Functional(string testCase, int expectedReturnCode)
         {

--- a/test/Cle.IntegrationTests/TestCases/CodeGenBringUp/LargeIf/LargeIf.cle
+++ b/test/Cle.IntegrationTests/TestCases/CodeGenBringUp/LargeIf/LargeIf.cle
@@ -1,0 +1,47 @@
+// This test verifies the compilation of a large PHI function.
+//
+// Expected return code: 32.
+// No console output expected.
+
+namespace LargeIf;
+
+[EntryPoint]
+public int32 Main()
+{
+    return Pow2(5);
+}
+
+public int32 Pow2(int32 n)
+{
+    int32 result = 1;
+    
+    if (n == 1) {
+        result = 2;
+    }
+    else if (n == 2) {
+        result = 4;
+    }
+    else if (n == 3) {
+        result = 8;
+    }
+    else if (n == 4) {
+        result = 16;
+    }
+    else if (n == 5) {
+        result = 32;
+    }
+    else if (n == 6) {
+        result = 64;
+    }
+    else if (n == 7) {
+        result = 128;
+    }
+    else if (n == 8) {
+        result = 256;
+    }
+    else if (n > 8) {
+        result = -1; // Just call it an overflow
+    }
+    
+    return result;
+}

--- a/test/Cle.IntegrationTests/TestCases/CodeGenBringUp/SwapAndReturnSmaller1/SwapAndReturnSmaller.cle
+++ b/test/Cle.IntegrationTests/TestCases/CodeGenBringUp/SwapAndReturnSmaller1/SwapAndReturnSmaller.cle
@@ -1,0 +1,23 @@
+// Two Phi functions feeding each other in a loop.
+//
+// Expected return code: 10.
+// No console output expected.
+
+namespace SwapAndReturnSmaller;
+
+[EntryPoint]
+public int32 Main()
+{
+    // The loop is executed - the opposite is tested by SwapAndReturnSmaller2
+    int32 a = 20;
+    int32 b = 10;
+    
+    while (a > b)
+    {
+        int32 temp = a;
+        a = b;
+        b = temp;
+    }
+
+    return a;
+}

--- a/test/Cle.IntegrationTests/TestCases/CodeGenBringUp/SwapAndReturnSmaller2/SwapAndReturnSmaller.cle
+++ b/test/Cle.IntegrationTests/TestCases/CodeGenBringUp/SwapAndReturnSmaller2/SwapAndReturnSmaller.cle
@@ -1,0 +1,23 @@
+// Two Phi functions feeding each other in a loop.
+//
+// Expected return code: 15.
+// No console output expected.
+
+namespace SwapAndReturnSmaller;
+
+[EntryPoint]
+public int32 Main()
+{
+    // The loop is NOT executed - the opposite is tested by SwapAndReturnSmaller1
+    int32 a = 15;
+    int32 b = 30;
+    
+    while (a > b)
+    {
+        int32 temp = a;
+        a = b;
+        b = temp;
+    }
+
+    return a;
+}

--- a/test/Cle.IntegrationTests/TestCases/Functional/IterativeFibonacci/IterativeFibonacci.cle
+++ b/test/Cle.IntegrationTests/TestCases/Functional/IterativeFibonacci/IterativeFibonacci.cle
@@ -1,0 +1,29 @@
+// Computes the Fibonacci number F(10) using the iterative method.
+//
+// Expected return code: 55.
+// No console output expected.
+
+namespace IterativeFibonacci;
+
+[EntryPoint]
+public int32 Main()
+{
+    return Fib(10);
+}
+
+private int32 Fib(int32 n)
+{
+    int32 a = 0;
+    int32 b = 1;
+    int32 i = 0;
+    
+    while (i < n)
+    {
+        int32 temp = a + b;
+        a = b;
+        b = temp;
+        i = i + 1;
+    }
+    
+    return a;
+}

--- a/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/IfTests.cs
+++ b/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/IfTests.cs
@@ -125,7 +125,9 @@ public int32 TheAnswer() {
 
             Assert.That(compiledMethod, Is.Not.Null);
             Assert.That(diagnostics.Diagnostics, Is.Empty);
-            
+
+            // BB_2 exists because direct BB_0 --> BB_3 would be a critical edge: BB_0 has two successors
+            // and BB_3 has two predecessors. This causes issues for SSA because the PHI cannot be resolved.
             AssertDisassembly(compiledMethod, @"
 ; #0   int32
 ; #1   bool
@@ -139,10 +141,14 @@ BB_0:
 BB_1:
     Load 1 -> #2
     CopyValue #2 -> #0
+    ==> BB_3
 
 BB_2:
+
+BB_3:
     Return #0");
         }
+
         [Test]
         public void If_and_else_both_assigning_to_variable()
         {
@@ -161,6 +167,8 @@ public int32 ComplexAnswer() {
             Assert.That(compiledMethod, Is.Not.Null);
             Assert.That(diagnostics.Diagnostics, Is.Empty);
 
+            // Here are no critical edges as BB_1 and BB_2, the predecessors of BB_3, have only a single
+            // successor each, and no other block has two predecessors.
             AssertDisassembly(compiledMethod, @"
 ; #0   int32
 ; #1   bool
@@ -348,7 +356,8 @@ public int32 TheAnswer() {
 
             Assert.That(compiledMethod, Is.Not.Null);
             Assert.That(diagnostics.Diagnostics, Is.Empty);
-            
+
+            // Although BB_5 has two predecessors, the edges are not critical since BB_1 and BB_3 do not branch
             AssertDisassembly(compiledMethod, @"
 ; #0   int32
 ; #1   bool

--- a/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/WhileTests.cs
+++ b/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/WhileTests.cs
@@ -54,6 +54,8 @@ public bool Stupid() {
             Assert.That(compiledMethod, Is.Not.Null);
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
+            // The empty BB_4 must exist because otherwise the BB_2 --> BB_5 edge would be critical:
+            // BB_2 has two successors and BB_5 has two predecessors (BB_3, and BB_2 via BB_4).
             AssertDisassembly(compiledMethod, @"
 ; #0   bool
 ; #1   bool
@@ -65,7 +67,7 @@ BB_0:
 BB_1:
     Load false -> #2
     BranchIf #2 ==> BB_2
-    ==> BB_5
+    ==> BB_6
 
 BB_2:
     BranchIf #0 ==> BB_3
@@ -73,11 +75,14 @@ BB_2:
 
 BB_3:
     CopyValue #0 -> #1
+    ==> BB_5
 
 BB_4:
-    ==> BB_1
 
 BB_5:
+    ==> BB_1
+
+BB_6:
     Return #1");
         }
 


### PR DESCRIPTION
Fixes #54 after suitable redefinition of the issue.

Implemented a proper LSRA algorithm as described by Franz and Wimmer. The location for a local is now represented by a set of live intervals, with possibly different locations in different basic blocks. I did not implement intra-block interval splitting or register preferences in this PR.

I'm not happy with the unit tests for the register allocator. Since it has many valid outputs, the best way to end-to-end test it is the integration test suite. There could be unit tests for each phase of the allocator, but that could be equally fragile.