### PR TITLE
Update the CI image to VS2019

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,17 +8,12 @@ trigger:
     - docs/*
 
 pool:
-  vmImage: 'vs2017-win2016'
+  vmImage: 'windows-2019'
 
 variables:
   configuration: 'Release'
-  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 'true'
 
 steps:
-- task: DotNetCoreInstaller@0
-  inputs:
-    version: '2.2.104'
-  displayName: 'Install .Net Core 2.2 SDK' # Needed for test filtering
 - script: |
     dotnet tool install --tool-path . nbgv
     .\nbgv cloud


### PR DESCRIPTION
Related to #45 and #51:
- no need to manually install .Net Core 2.2 SDK any more,
- compiler supports C# 8.0.