### PR TITLE
Start the 0.2 development cycle

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,6 +33,7 @@ steps:
 - task: ArchiveFiles@2
   inputs:
     rootFolderOrFile: '$(Build.ArtifactStagingDirectory)'
+    includeRootFolder: false
     archiveFile: '$(Build.ArtifactStagingDirectory)/cle-$(Build.BuildNumber).zip'
   displayName: 'Create .zip file'
 - task: PublishBuildArtifacts@1

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,7 @@ Clé is a C-like programming language compiled to optimized native code.
 As a hobby/learning project of [@polsys](https://github.com/polsys), it is purposefully feature-poor, but at the same time aims to avoid typical footguns of the C world.
 If you know C#, you will be immediately familiar; the language is also inspired by Rust.
 
+<a class="button" href="https://github.com/polsys/cle/releases">Download</a>
 
 ## Language specification
 This is an almost rigorous reference for the language.

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1",
+  "version": "0.2",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/heads/release/\\d+\\.\\d+"


### PR DESCRIPTION
Bumped the version to 0.2, fixed one last issue from #67 and added a download link to the GitHub Pages page.