### PR TITLE
Update projects to C# 8

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,10 @@ variables:
   configuration: 'Release'
 
 steps:
+- task: DotNetCoreInstaller@0
+  inputs:
+    version: '2.2.203'
+  displayName: 'Install .NET Core SDK that supports C# 8.0'
 - script: |
     dotnet tool install --tool-path . nbgv
     .\nbgv cloud

--- a/src/Cle.CodeGeneration/Cle.CodeGeneration.csproj
+++ b/src/Cle.CodeGeneration/Cle.CodeGeneration.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   

--- a/src/Cle.CodeGeneration/Cle.CodeGeneration.csproj
+++ b/src/Cle.CodeGeneration/Cle.CodeGeneration.csproj
@@ -4,10 +4,10 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NullableContextOptions>enable</NullableContextOptions>
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2018.2.1" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="System.Memory" Version="4.5.1" />
   </ItemGroup>

--- a/src/Cle.CodeGeneration/Lir/LowBlock.cs
+++ b/src/Cle.CodeGeneration/Lir/LowBlock.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Cle.SemanticAnalysis.IR;
-using JetBrains.Annotations;
 
 namespace Cle.CodeGeneration.Lir
 {
@@ -12,26 +12,22 @@ namespace Cle.CodeGeneration.Lir
         /// <summary>
         /// Gets a linear list of lowered instructions in this block.
         /// </summary>
-        [NotNull]
         public readonly List<LowInstruction> Instructions;
 
         /// <summary>
         /// Gets a read-only list of Phi nodes executed at the start of this block.
         /// Can be null.
         /// </summary>
-        [CanBeNull, ItemNotNull]
-        public IReadOnlyList<Phi> Phis;
+        public IReadOnlyList<Phi>? Phis;
 
         /// <summary>
         /// Gets a list of predecessors of this basic block.
         /// </summary>
-        [NotNull]
         public IReadOnlyList<int> Predecessors;
 
         /// <summary>
         /// Gets a list of successors of this basic block.
         /// </summary>
-        [NotNull]
         public IReadOnlyList<int> Successors;
 
         public LowBlock() : this(new List<LowInstruction>())
@@ -41,6 +37,8 @@ namespace Cle.CodeGeneration.Lir
         public LowBlock(List<LowInstruction> instructions)
         {
             Instructions = instructions;
+            Predecessors = Array.Empty<int>();
+            Successors = Array.Empty<int>();
         }
     }
 }

--- a/src/Cle.CodeGeneration/Lir/LowMethod.cs
+++ b/src/Cle.CodeGeneration/Lir/LowMethod.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using JetBrains.Annotations;
 
 namespace Cle.CodeGeneration.Lir
 {
@@ -14,10 +13,8 @@ namespace Cle.CodeGeneration.Lir
     internal class LowMethod<TRegister>
         where TRegister : struct, Enum
     {
-        [NotNull, ItemNotNull]
         public readonly List<LowLocal<TRegister>> Locals;
 
-        [NotNull, ItemNotNull]
         public readonly List<LowBlock> Blocks;
 
         public LowMethod()
@@ -36,7 +33,7 @@ namespace Cle.CodeGeneration.Lir
         /// </summary>
         /// <param name="writer">A writer instance.</param>
         /// <param name="printLocals">If true, the locals and their required locations will be printed.</param>
-        public void Dump([NotNull] TextWriter writer, bool printLocals)
+        public void Dump(TextWriter writer, bool printLocals)
         {
             if (printLocals)
             {

--- a/src/Cle.CodeGeneration/LoweringX64.cs
+++ b/src/Cle.CodeGeneration/LoweringX64.cs
@@ -3,7 +3,6 @@ using System.Diagnostics;
 using Cle.CodeGeneration.Lir;
 using Cle.Common.TypeSystem;
 using Cle.SemanticAnalysis.IR;
-using JetBrains.Annotations;
 
 namespace Cle.CodeGeneration
 {
@@ -12,7 +11,7 @@ namespace Cle.CodeGeneration
     /// </summary>
     internal static class LoweringX64
     {
-        public static LowMethod<X64Register> Lower([NotNull] CompiledMethod highMethod)
+        public static LowMethod<X64Register> Lower(CompiledMethod highMethod)
         {
             Debug.Assert(highMethod.Body != null);
             Debug.Assert(highMethod.Body.BasicBlocks.Count > 0);
@@ -70,8 +69,8 @@ namespace Cle.CodeGeneration
             }
         }
 
-        private static LowBlock ConvertBlock([NotNull] BasicBlock highBlock, [NotNull] CompiledMethod highMethod,
-            [NotNull] LowMethod<X64Register> methodInProgress, bool isFirstBlock, int paramCount)
+        private static LowBlock ConvertBlock(BasicBlock highBlock, CompiledMethod highMethod,
+            LowMethod<X64Register> methodInProgress, bool isFirstBlock, int paramCount)
         {
             var lowBlock = new LowBlock
             {

--- a/src/Cle.CodeGeneration/PeepholeOptimizer.cs
+++ b/src/Cle.CodeGeneration/PeepholeOptimizer.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using Cle.CodeGeneration.Lir;
-using JetBrains.Annotations;
 
 namespace Cle.CodeGeneration
 {
@@ -17,7 +16,7 @@ namespace Cle.CodeGeneration
         /// Optimizes the given LIR.
         /// </summary>
         /// <param name="method">The method to optimize. The blocks will be mutated in place.</param>
-        public static void Optimize([NotNull] LowMethod<TRegister> method)
+        public static void Optimize(LowMethod<TRegister> method)
         {
             // As an extension to a basic peephole optimizer, count the uses of locals
             // TODO: Get a pooled array
@@ -32,7 +31,7 @@ namespace Cle.CodeGeneration
             }
         }
 
-        private static void CountUses([NotNull] LowMethod<TRegister> method, [NotNull] int[] uses)
+        private static void CountUses(LowMethod<TRegister> method, int[] uses)
         {
             // A variable is counted as used if it has a fixed storage location
             // For example, the Return op implicitly uses the local stored in the return register
@@ -55,7 +54,7 @@ namespace Cle.CodeGeneration
             }
         }
 
-        private static void OptimizeBlock([NotNull] List<LowInstruction> block, [NotNull] int[] localUses)
+        private static void OptimizeBlock(List<LowInstruction> block, int[] localUses)
         {
             var currentPos = 0;
             while (currentPos < block.Count)
@@ -70,7 +69,7 @@ namespace Cle.CodeGeneration
         /// Applies peephole patterns that are important for code quality even in non-optimizing builds.
         /// These fix up silly patterns created by lowering and help out register allocation.
         /// </summary>
-        private static bool PeepBasic([NotNull] List<LowInstruction> block, int currentPos, [NotNull] int[] localUses)
+        private static bool PeepBasic(List<LowInstruction> block, int currentPos, int[] localUses)
         {
             var current = block[currentPos]; // TODO: This might be an expensive copy
             var instructionsLeft = block.Count - currentPos - 1;

--- a/src/Cle.CodeGeneration/PortableExecutableWriter.cs
+++ b/src/Cle.CodeGeneration/PortableExecutableWriter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using JetBrains.Annotations;
 
 namespace Cle.CodeGeneration
 {
@@ -13,11 +12,10 @@ namespace Cle.CodeGeneration
         /// <summary>
         /// Gets the instruction emitter associated with this PE file.
         /// </summary>
-        [NotNull]
         public X64Emitter Emitter { get; }
 
-        [CanBeNull] private readonly TextWriter _disassemblyWriter;
-        [NotNull] private readonly Stream _exeStream;
+        private readonly TextWriter? _disassemblyWriter;
+        private readonly Stream _exeStream;
         private int _entryPointOffset;
 
         private readonly List<Fixup> _callFixups = new List<Fixup>();
@@ -29,7 +27,7 @@ namespace Cle.CodeGeneration
         private const int BaseOfCodeAddress = 0x00001000; // The default
         private const int PeHeaderSize = 0x0400; // 1024 bytes, a safe bet
         
-        public PortableExecutableWriter([NotNull] Stream outputStream, [CanBeNull] TextWriter disassemblyWriter)
+        public PortableExecutableWriter(Stream outputStream, TextWriter? disassemblyWriter)
         {
             Emitter = new X64Emitter(outputStream, disassemblyWriter);
             _exeStream = outputStream;
@@ -47,7 +45,7 @@ namespace Cle.CodeGeneration
         /// </summary>
         /// <param name="methodIndex">The compiler internal method index.</param>
         /// <param name="methodName">The full method name, used for disassembly.</param>
-        public void StartNewMethod(int methodIndex, [NotNull] string methodName)
+        public void StartNewMethod(int methodIndex, string methodName)
         {
             // Methods always start at multiple of 16 bytes
             WritePadding(16, _int3Padding);

--- a/src/Cle.CodeGeneration/RegisterAllocation/AllocationInfo.cs
+++ b/src/Cle.CodeGeneration/RegisterAllocation/AllocationInfo.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using Cle.CodeGeneration.Lir;
-using JetBrains.Annotations;
 
 namespace Cle.CodeGeneration.RegisterAllocation
 {
@@ -15,11 +14,10 @@ namespace Cle.CodeGeneration.RegisterAllocation
     {
         public int IntervalCount => _intervals.Count;
 
-        [NotNull, ItemNotNull]
         private readonly List<Interval<TRegister>> _intervals;
 
         /// <param name="intervals">The list must match the value numbers in low instructions.</param>
-        internal AllocationInfo([NotNull, ItemNotNull] List<Interval<TRegister>> intervals)
+        internal AllocationInfo(List<Interval<TRegister>> intervals)
         {
             _intervals = intervals;
         }
@@ -35,7 +33,7 @@ namespace Cle.CodeGeneration.RegisterAllocation
             return (new StorageLocation<TRegister>(interval.Register), interval.LocalIndex);
         }
 
-        internal void Dump([NotNull] TextWriter dumpWriter)
+        internal void Dump(TextWriter dumpWriter)
         {
             foreach (var interval in _intervals)
             {

--- a/src/Cle.CodeGeneration/RegisterAllocation/X64RegisterAllocator.cs
+++ b/src/Cle.CodeGeneration/RegisterAllocation/X64RegisterAllocator.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using Cle.CodeGeneration.Lir;
-using JetBrains.Annotations;
 
 using Interval = Cle.CodeGeneration.RegisterAllocation.Interval<Cle.CodeGeneration.Lir.X64Register>;
 
@@ -50,7 +49,7 @@ namespace Cle.CodeGeneration.RegisterAllocation
         /// The method must be in SSA form with critical edges broken.
         /// </param>
         public static (LowMethod<X64Register> allocatedMethod, AllocationInfo<X64Register> allocationInfo)
-            Allocate([NotNull] LowMethod<X64Register> method)
+            Allocate(LowMethod<X64Register> method)
         {
             // Compute the live intervals
             var intervals = new List<Interval>(method.Locals.Count);
@@ -117,11 +116,12 @@ namespace Cle.CodeGeneration.RegisterAllocation
                     {
                         live.UnionWith(liveIn[succ]);
 
-                        if (method.Blocks[succ].Phis is null)
+                        var phis = method.Blocks[succ].Phis;
+                        if (phis is null)
                             continue;
 
                         var phiPosition = GetPhiOperandIndex(blockIndex, method.Blocks[succ]);
-                        foreach (var phi in method.Blocks[succ].Phis)
+                        foreach (var phi in phis)
                             live.Add(phi.Operands[phiPosition]);
                     }
                 }

--- a/src/Cle.CodeGeneration/WindowsX64CodeGenerator.cs
+++ b/src/Cle.CodeGeneration/WindowsX64CodeGenerator.cs
@@ -6,16 +6,15 @@ using Cle.CodeGeneration.Lir;
 using Cle.CodeGeneration.RegisterAllocation;
 using Cle.Common.TypeSystem;
 using Cle.SemanticAnalysis.IR;
-using JetBrains.Annotations;
 
 namespace Cle.CodeGeneration
 {
     public sealed class WindowsX64CodeGenerator
     {
-        [NotNull] private readonly PortableExecutableWriter _peWriter;
-        [NotNull] private readonly List<Fixup> _fixupsForMethod;
-        [NotNull] private readonly List<int> _blockPositions;
-        [NotNull] private readonly List<X64Register> _savedRegisters;
+        private readonly PortableExecutableWriter _peWriter;
+        private readonly List<Fixup> _fixupsForMethod;
+        private readonly List<int> _blockPositions;
+        private readonly List<X64Register> _savedRegisters;
 
         /// <summary>
         /// Creates a code generator instance with the specified output stream and optional disassembly stream.
@@ -28,7 +27,7 @@ namespace Cle.CodeGeneration
         /// <param name="disassemblyWriter">
         /// Optional text writer for method disassembly.
         /// </param>
-        public WindowsX64CodeGenerator([NotNull] Stream outputStream, [CanBeNull] TextWriter disassemblyWriter)
+        public WindowsX64CodeGenerator(Stream outputStream, TextWriter? disassemblyWriter)
         {
             _peWriter = new PortableExecutableWriter(outputStream, disassemblyWriter);
             _fixupsForMethod = new List<Fixup>();
@@ -51,8 +50,7 @@ namespace Cle.CodeGeneration
         /// <param name="methodIndex">The compiler internal index for the method.</param>
         /// <param name="isEntryPoint">If true, this method is marked as the executable entry point.</param>
         /// <param name="dumpWriter">An optional text writer for debug dumping of the current method.</param>
-        public void EmitMethod([NotNull] CompiledMethod method, int methodIndex, bool isEntryPoint,
-            [CanBeNull] TextWriter dumpWriter)
+        public void EmitMethod(CompiledMethod method, int methodIndex, bool isEntryPoint, TextWriter? dumpWriter)
         {
             _fixupsForMethod.Clear();
             _blockPositions.Clear();
@@ -454,8 +452,8 @@ namespace Cle.CodeGeneration
             }
         }
 
-        private static void DebugLogBeforeAllocation([NotNull] LowMethod<X64Register> loweredMethod,
-            [NotNull] string methodFullName, [NotNull] TextWriter dumpWriter)
+        private static void DebugLogBeforeAllocation(LowMethod<X64Register> loweredMethod,
+            string methodFullName, TextWriter dumpWriter)
         {
             // Dump the LIR with locals
             dumpWriter.Write("; Lowered IR for ");
@@ -466,8 +464,8 @@ namespace Cle.CodeGeneration
             dumpWriter.WriteLine();
         }
 
-        private static void DebugLogAfterAllocation([NotNull] LowMethod<X64Register> allocatedMethod,
-            [NotNull] AllocationInfo<X64Register> allocationInfo, [NotNull] TextWriter dumpWriter)
+        private static void DebugLogAfterAllocation(LowMethod<X64Register> allocatedMethod,
+            AllocationInfo<X64Register> allocationInfo, TextWriter dumpWriter)
         {
             dumpWriter.WriteLine("; After register allocation");
 

--- a/src/Cle.CodeGeneration/X64Emitter.cs
+++ b/src/Cle.CodeGeneration/X64Emitter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using Cle.CodeGeneration.Lir;
-using JetBrains.Annotations;
 
 namespace Cle.CodeGeneration
 {
@@ -11,13 +10,13 @@ namespace Cle.CodeGeneration
     /// </summary>
     internal sealed class X64Emitter
     {
-        [NotNull] private readonly Stream _outputStream;
-        [CanBeNull] private readonly TextWriter _disassemblyWriter;
+        private readonly Stream _outputStream;
+        private readonly TextWriter? _disassemblyWriter;
         private readonly byte[] _tempBuffer = new byte[8];
 
         private const string Indent = "    ";
 
-        public X64Emitter([NotNull] Stream outputStream, [CanBeNull] TextWriter disassemblyWriter)
+        public X64Emitter(Stream outputStream, TextWriter? disassemblyWriter)
         {
             _outputStream = outputStream;
             _disassemblyWriter = disassemblyWriter;
@@ -456,7 +455,7 @@ namespace Cle.CodeGeneration
         /// </summary>
         /// <param name="target">The target byte where the execution will be transferred to.</param>
         /// <param name="methodName">The target name for disassembly.</param>
-        public void EmitCall(int target, [NotNull] string methodName)
+        public void EmitCall(int target, string methodName)
         {
             _disassemblyWriter?.WriteLine($"{Indent}call {methodName}");
 
@@ -470,7 +469,7 @@ namespace Cle.CodeGeneration
         /// <param name="targetIndex">Method index to call. This will be used as the fixup tag.</param>
         /// <param name="methodName">The target name for disassembly.</param>
         /// <param name="fixup">Information required for fixing the target later.</param>
-        public void EmitCallWithFixup(int targetIndex, [NotNull] string methodName, out Fixup fixup)
+        public void EmitCallWithFixup(int targetIndex, string methodName, out Fixup fixup)
         {
             // The call opcode is a single byte
             fixup = new Fixup(FixupType.RelativeJump, targetIndex, (int)_outputStream.Position + 1);

--- a/src/Cle.Common/Cle.Common.csproj
+++ b/src/Cle.Common/Cle.Common.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Cle.Common/Cle.Common.csproj
+++ b/src/Cle.Common/Cle.Common.csproj
@@ -3,10 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
+    <NullableContextOptions>enable</NullableContextOptions>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2018.2.1" />
-  </ItemGroup>
 
 </Project>

--- a/src/Cle.Common/Diagnostic.cs
+++ b/src/Cle.Common/Diagnostic.cs
@@ -1,6 +1,4 @@
-﻿using JetBrains.Annotations;
-
-namespace Cle.Common
+﻿namespace Cle.Common
 {
     /// <summary>
     /// Represents a compilation diagnostic code along with source position and additional information.
@@ -16,15 +14,13 @@ namespace Cle.Common
         /// The content of this value depends on the diagnostic code.
         /// This may be null.
         /// </summary>
-        [CanBeNull]
-        public string Actual { get; }
+        public string? Actual { get; }
 
         /// <summary>
         /// The content of this value depends on the diagnostic code.
         /// This may be null.
         /// </summary>
-        [CanBeNull]
-        public string Expected { get; }
+        public string? Expected { get; }
 
         /// <summary>
         /// Gets whether the diagnostic code is classified as an error or not.
@@ -41,14 +37,13 @@ namespace Cle.Common
 
         /// <summary>
         /// Gets the name of the file where the diagnostic occurred.
+        /// This may be null.
         /// </summary>
-        [CanBeNull]
-        public string Filename { get; }
+        public string? Filename { get; }
 
         /// <summary>
         /// Gets the name of the module containing the source file.
         /// </summary>
-        [NotNull]
         public string Module { get; }
 
         /// <summary>
@@ -56,13 +51,13 @@ namespace Cle.Common
         /// </summary>
         /// <param name="code">The diagnostic code.</param>
         /// <param name="position">The position within the source file.</param>
-        /// <param name="filename">The source file name.</param>
+        /// <param name="filename">The source file name (optional if no associated file).</param>
         /// <param name="moduleName">The module name.</param>
         /// <param name="actual">Optional actual value encountered.</param>
         /// <param name="expected">Optional expected value.</param>
         public Diagnostic(DiagnosticCode code, TextPosition position,
-            [CanBeNull] string filename, [NotNull] string moduleName,
-            [CanBeNull] string actual, [CanBeNull] string expected)
+            string? filename, string moduleName,
+            string? actual, string? expected)
         {
             Code = code;
             Position = position;

--- a/src/Cle.Common/IDiagnosticSink.cs
+++ b/src/Cle.Common/IDiagnosticSink.cs
@@ -13,11 +13,11 @@
         /// <summary>
         /// Adds the specified diagnostic at given location with actual (unexpected) value.
         /// </summary>
-        void Add(DiagnosticCode code, TextPosition position, string actual);
+        void Add(DiagnosticCode code, TextPosition position, string? actual);
 
         /// <summary>
         /// Adds the specified diagnostic at given location with actual and expected value.
         /// </summary>
-        void Add(DiagnosticCode code, TextPosition position, string actual, string expected);
+        void Add(DiagnosticCode code, TextPosition position, string? actual, string? expected);
     }
 }

--- a/src/Cle.Common/NullabilityAttributes.cs
+++ b/src/Cle.Common/NullabilityAttributes.cs
@@ -1,0 +1,33 @@
+﻿// These attributes are not yet available in the base class library
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
+    public class AssertsTrueAttribute : Attribute
+    {
+        public AssertsTrueAttribute() { }
+    }
+
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
+    public class AssertsFalseAttribute : Attribute
+    {
+        public AssertsFalseAttribute() { }
+    }
+
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
+    public class EnsuresNotNullAttribute : Attribute
+    {
+        public EnsuresNotNullAttribute() { }
+    }
+
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
+    public class NotNullWhenFalseAttribute : Attribute
+    {
+        public NotNullWhenFalseAttribute() { }
+    }
+
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
+    public class NotNullWhenTrueAttribute : Attribute
+    {
+        public NotNullWhenTrueAttribute() { }
+    }
+}

--- a/src/Cle.Common/TypeSystem/SimpleType.cs
+++ b/src/Cle.Common/TypeSystem/SimpleType.cs
@@ -6,7 +6,7 @@ namespace Cle.Common.TypeSystem
     /// Represents built-in value types.
     /// Use the static properties to access type instances.
     /// </summary>
-    public class SimpleType : TypeDefinition, IEquatable<SimpleType>
+    public class SimpleType : TypeDefinition, IEquatable<SimpleType?>
     {
         public static SimpleType Void { get; } = new SimpleType(SimpleTypeId.Void, false, 0);
         public static SimpleType Bool { get; } = new SimpleType(SimpleTypeId.Bool, false, 1);
@@ -24,7 +24,7 @@ namespace Cle.Common.TypeSystem
             SizeInBytes = size;
         }
 
-        public bool Equals(SimpleType other)
+        public bool Equals(SimpleType? other)
         {
             return _typeId == other?._typeId;
         }
@@ -46,12 +46,12 @@ namespace Cle.Common.TypeSystem
 
         public override int SizeInBytes { get; }
 
-        public override bool Equals(TypeDefinition other)
+        public override bool Equals(TypeDefinition? other)
         {
             return other is SimpleType simpleType && Equals(simpleType);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is SimpleType simpleType && Equals(simpleType);
         }

--- a/src/Cle.Common/TypeSystem/TypeDefinition.cs
+++ b/src/Cle.Common/TypeSystem/TypeDefinition.cs
@@ -7,7 +7,7 @@ namespace Cle.Common.TypeSystem
     /// Each type is defined exactly once and the <see cref="Equals(TypeDefinition)"/> method
     /// can be used for comparing types.
     /// </summary>
-    public abstract class TypeDefinition : IEquatable<TypeDefinition>
+    public abstract class TypeDefinition : IEquatable<TypeDefinition?>
     {
         /// <summary>
         /// Gets the fully qualified name of this type.
@@ -19,8 +19,8 @@ namespace Cle.Common.TypeSystem
         /// </summary>
         public abstract int SizeInBytes { get; }
 
-        public abstract bool Equals(TypeDefinition other);
-        public abstract override bool Equals(object obj);
+        public abstract bool Equals(TypeDefinition? other);
+        public abstract override bool Equals(object? obj);
         public abstract override int GetHashCode();
     }
 }

--- a/src/Cle.Compiler/Cle.Compiler.csproj
+++ b/src/Cle.Compiler/Cle.Compiler.csproj
@@ -3,10 +3,10 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
+    <NullableContextOptions>enable</NullableContextOptions>
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2018.2.1" />
     <PackageReference Include="System.Memory" Version="4.5.1" />
   </ItemGroup>
   

--- a/src/Cle.Compiler/Cle.Compiler.csproj
+++ b/src/Cle.Compiler/Cle.Compiler.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Cle.Compiler/Compilation.cs
+++ b/src/Cle.Compiler/Compilation.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using Cle.Common;
 using Cle.SemanticAnalysis;
 using Cle.SemanticAnalysis.IR;
-using JetBrains.Annotations;
 
 namespace Cle.Compiler
 {
@@ -20,14 +19,11 @@ namespace Cle.Compiler
         /// Gets the list of diagnostics associated with this compilation.
         /// <see cref="DiagnosticsLock"/> must be acquired prior to accessing this property.
         /// </summary>
-        [NotNull]
-        [ItemNotNull]
         public IReadOnlyList<Diagnostic> Diagnostics => _diagnostics;
 
         /// <summary>
         /// Synchronization object for <see cref="Diagnostics"/>.
         /// </summary>
-        [NotNull]
         public object DiagnosticsLock { get; } = new object();
 
         /// <summary>
@@ -57,8 +53,6 @@ namespace Cle.Compiler
             }
         }
 
-        [NotNull]
-        [ItemNotNull]
         private readonly List<Diagnostic> _diagnostics = new List<Diagnostic>();
 
         /// <summary>
@@ -66,18 +60,14 @@ namespace Cle.Compiler
         /// Second level: method name.
         /// Third level: list of methods with the name (because of private methods, may have more than one).
         /// </summary>
-        [NotNull]
         private readonly Dictionary<string, Dictionary<string, List<MethodDeclaration>>> _methodDeclarations =
             new Dictionary<string, Dictionary<string, List<MethodDeclaration>>>();
 
-        [NotNull]
         private readonly object _declarationLock = new object();
 
-        [NotNull]
         private readonly IndexedRandomAccessStore<CompiledMethod> _methodBodies =
             new IndexedRandomAccessStore<CompiledMethod>();
 
-        [NotNull]
         private readonly object _methodBodyLock = new object();
         private int _entryPointIndex = -1;
 
@@ -85,7 +75,7 @@ namespace Cle.Compiler
         /// Adds the given collection of diagnostics to <see cref="Diagnostics"/>.
         /// This function may be called from multiple threads.
         /// </summary>
-        public void AddDiagnostics([NotNull] IReadOnlyList<Diagnostic> diagnosticsToAdd)
+        public void AddDiagnostics(IReadOnlyList<Diagnostic> diagnosticsToAdd)
         {
             lock (DiagnosticsLock)
             {
@@ -106,7 +96,7 @@ namespace Cle.Compiler
         /// </summary>
         /// <param name="moduleName">The module that should contain the file.</param>
         /// <param name="filename">The name of the missing file.</param>
-        public void AddMissingFileError([NotNull] string moduleName, [NotNull] string filename)
+        public void AddMissingFileError(string moduleName, string filename)
         {
             lock (DiagnosticsLock)
             {
@@ -122,7 +112,7 @@ namespace Cle.Compiler
         /// </summary>
         /// <param name="code">The error code.</param>
         /// <param name="moduleName">The module that was not found.</param>
-        public void AddModuleLevelDiagnostic(DiagnosticCode code, [NotNull] string moduleName)
+        public void AddModuleLevelDiagnostic(DiagnosticCode code, string moduleName)
         {
             lock (DiagnosticsLock)
             {
@@ -141,9 +131,9 @@ namespace Cle.Compiler
         /// <param name="declaration">The method declaration to be associated with the full method name.</param>
         // TODO: Modules
         public bool AddMethodDeclaration(
-            [NotNull] string methodName,
-            [NotNull] string namespaceName,
-            [NotNull] MethodDeclaration declaration)
+            string methodName,
+            string namespaceName,
+            MethodDeclaration declaration)
         {
             // TODO: This imposes a performance penalty, especially as adds typically happen in a batch.
             // TODO: Investigate when we have a realistic workload.
@@ -197,11 +187,10 @@ namespace Cle.Compiler
         /// <param name="visibleNamespaces">Namespaces available for searching the method.</param>
         /// <param name="sourceFile">The current source file, used for matching private methods.</param>
         // TODO: Modules
-        [NotNull, ItemNotNull]
         public IReadOnlyList<MethodDeclaration> GetMethodDeclarations(
-            [NotNull] string methodName,
-            [NotNull, ItemNotNull] IReadOnlyList<string> visibleNamespaces,
-            [NotNull] string sourceFile)
+            string methodName,
+            IReadOnlyList<string> visibleNamespaces,
+            string sourceFile)
         {
             var matchingMethods = ImmutableList<MethodDeclaration>.Empty;
 
@@ -252,7 +241,6 @@ namespace Cle.Compiler
         /// Returns the method body associated with the given index.
         /// Throws if there is no method stored.
         /// </summary>
-        [NotNull]
         public CompiledMethod GetMethodBody(int index)
         {
             try
@@ -273,7 +261,7 @@ namespace Cle.Compiler
         /// </summary>
         /// <param name="index">The method index from <see cref="ReserveMethodSlot"/>. Throws if this is not valid.</param>
         /// <param name="method">The method to store.</param>
-        public void SetMethodBody(int index, [NotNull] CompiledMethod method)
+        public void SetMethodBody(int index, CompiledMethod method)
         {
             try
             {

--- a/src/Cle.Compiler/CompilationOptions.cs
+++ b/src/Cle.Compiler/CompilationOptions.cs
@@ -1,6 +1,4 @@
-﻿using JetBrains.Annotations;
-
-namespace Cle.Compiler
+﻿namespace Cle.Compiler
 {
     /// <summary>
     /// Additional options for the compiler.
@@ -16,8 +14,7 @@ namespace Cle.Compiler
         /// <summary>
         /// Gets a regex pattern the will be used for matching method names to dump debug logging for.
         /// </summary>
-        [CanBeNull]
-        public string DebugPattern { get; }
+        public string? DebugPattern { get; }
 
         /// <summary>
         /// If true, an assembly language listing for the compiled program should be produced along the executable.
@@ -27,10 +24,9 @@ namespace Cle.Compiler
         /// <summary>
         /// Gets the name of the main module.
         /// </summary>
-        [NotNull]
         public string MainModule { get; }
 
-        public CompilationOptions([NotNull] string mainModule, string debugPattern = null, bool emitDisassembly = false)
+        public CompilationOptions(string mainModule, string? debugPattern = null, bool emitDisassembly = false)
         {
             MainModule = mainModule;
             DebugPattern = debugPattern;

--- a/src/Cle.Compiler/CompilationResult.cs
+++ b/src/Cle.Compiler/CompilationResult.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using Cle.Common;
-using JetBrains.Annotations;
 
 namespace Cle.Compiler
 {
@@ -32,7 +31,7 @@ namespace Cle.Compiler
         public IReadOnlyList<Diagnostic> Diagnostics { get; }
 
         internal CompilationResult(int moduleCount, int succeededCount, int failedCount,
-            [NotNull, ItemNotNull] IReadOnlyList<Diagnostic> diagnostics)
+            IReadOnlyList<Diagnostic> diagnostics)
         {
             ModuleCount = moduleCount;
             SucceededCount = succeededCount;

--- a/src/Cle.Compiler/CompilerDriver.cs
+++ b/src/Cle.Compiler/CompilerDriver.cs
@@ -7,7 +7,6 @@ using Cle.Common;
 using Cle.Parser;
 using Cle.Parser.SyntaxTree;
 using Cle.SemanticAnalysis;
-using JetBrains.Annotations;
 
 namespace Cle.Compiler
 {
@@ -23,11 +22,10 @@ namespace Cle.Compiler
         /// <param name="options">Additional options, such as optimization and logging levels.</param>
         /// <param name="sourceFileProvider">Interface for source file access.</param>
         /// <param name="outputFileProvider">Interface for output file access.</param>
-        [NotNull]
         public static CompilationResult Compile(
-            [NotNull] CompilationOptions options,
-            [NotNull] ISourceFileProvider sourceFileProvider,
-            [NotNull] IOutputFileProvider outputFileProvider)
+            CompilationOptions options,
+            ISourceFileProvider sourceFileProvider,
+            IOutputFileProvider outputFileProvider)
         {
             // TODO: Determinism (basically, compile everything in a fixed order)
 
@@ -102,8 +100,8 @@ namespace Cle.Compiler
         /// Parses a single module and returns the successfully parsed syntax trees.
         /// Adds parsing diagnostics to the compilation.
         /// </summary>
-        internal static void ParseModule([NotNull] string moduleName, [NotNull] Compilation compilation,
-            [NotNull] ISourceFileProvider fileProvider, [NotNull, ItemNotNull] out List<SourceFileSyntax> syntaxTrees)
+        internal static void ParseModule(string moduleName, Compilation compilation,
+            ISourceFileProvider fileProvider, out List<SourceFileSyntax> syntaxTrees)
         {
             syntaxTrees = new List<SourceFileSyntax>();
 
@@ -141,9 +139,9 @@ namespace Cle.Compiler
         }
 
         private static void AddDeclarationsForModule(
-            [NotNull] string moduleName,
-            [NotNull] Compilation compilation,
-            [NotNull, ItemNotNull] List<SourceFileSyntax> syntaxTrees)
+            string moduleName,
+            Compilation compilation,
+            List<SourceFileSyntax> syntaxTrees)
         {
             var diagnosticSink = new SingleFileDiagnosticSink();
 
@@ -188,10 +186,10 @@ namespace Cle.Compiler
         }
 
         private static void CompileModule(
-            [NotNull] string moduleName,
-            [NotNull] Compilation compilation,
-            [NotNull, ItemNotNull] List<SourceFileSyntax> syntaxTrees,
-            [NotNull] DebugLogger debugLogger)
+            string moduleName,
+            Compilation compilation,
+            List<SourceFileSyntax> syntaxTrees,
+            DebugLogger debugLogger)
         {
             var diagnosticSink = new SingleFileDiagnosticSink();
             var compiler = new MethodCompiler(compilation, diagnosticSink);
@@ -237,8 +235,8 @@ namespace Cle.Compiler
             }
         }
 
-        private static void GenerateCode([NotNull] Compilation compilation, [NotNull] Stream outputStream,
-            [CanBeNull] TextWriter disassemblyWriter, [NotNull] DebugLogger debugLogger)
+        private static void GenerateCode(Compilation compilation, Stream outputStream,
+            TextWriter? disassemblyWriter, DebugLogger debugLogger)
         {
             var generator = new WindowsX64CodeGenerator(outputStream, disassemblyWriter);
             

--- a/src/Cle.Compiler/DebugLogger.cs
+++ b/src/Cle.Compiler/DebugLogger.cs
@@ -1,9 +1,9 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Text;
 using Cle.SemanticAnalysis;
 using Cle.SemanticAnalysis.IR;
-using JetBrains.Annotations;
 
 namespace Cle.Compiler
 {
@@ -12,13 +12,12 @@ namespace Cle.Compiler
     /// </summary>
     internal class DebugLogger
     {
-        [CanBeNull] private readonly string _pattern;
+        private readonly string? _pattern;
 
         /// <summary>
         /// Gets the internal writer, which may be null.
         /// </summary>
-        [CanBeNull]
-        public TextWriter Writer { get; }
+        public TextWriter? Writer { get; }
 
         /// <summary>
         /// Creates a logger.
@@ -31,7 +30,7 @@ namespace Cle.Compiler
         /// A string that is searched for in method names.
         /// A null pattern matches no method and "*" or empty matches all methods.
         /// </param>
-        public DebugLogger([CanBeNull] TextWriter writer, [CanBeNull] string methodPattern)
+        public DebugLogger(TextWriter? writer, string? methodPattern)
         {
             Writer = writer;
 
@@ -47,7 +46,7 @@ namespace Cle.Compiler
         /// Returns true iff the method name contains the pattern string and logging is enabled. 
         /// </summary>
         /// <param name="methodName">The full name of the method to match.</param>
-        public bool ShouldLog([NotNull] string methodName)
+        public bool ShouldLog(string methodName)
         {
             return Writer != null && _pattern != null &&
                 methodName.IndexOf(_pattern, StringComparison.InvariantCultureIgnoreCase) != -1;
@@ -58,10 +57,11 @@ namespace Cle.Compiler
         /// to the output writer.
         /// </summary>
         /// <param name="method">The method IR.</param>
-        public void DumpMethod([NotNull] CompiledMethod method)
+        public void DumpMethod(CompiledMethod method)
         {
             if (!ShouldLog(method.FullName))
                 return;
+            Debug.Assert(Writer is object);
 
             // Write the full name as a comment
             Writer.Write("; ");
@@ -87,7 +87,7 @@ namespace Cle.Compiler
         /// Writes a header surrounded by padding and a header sign.
         /// </summary>
         /// <param name="header">The header text.</param>
-        public void WriteHeader([NotNull] string header)
+        public void WriteHeader(string header)
         {
             if (Writer != null)
             {
@@ -102,7 +102,7 @@ namespace Cle.Compiler
         /// <summary>
         /// Writes the specified text followed by a newline.
         /// </summary>
-        public void WriteLine([NotNull] string text)
+        public void WriteLine(string text)
         {
             Writer?.WriteLine(text);
         }

--- a/src/Cle.Compiler/IOutputFileProvider.cs
+++ b/src/Cle.Compiler/IOutputFileProvider.cs
@@ -1,5 +1,4 @@
 ﻿using System.IO;
-using JetBrains.Annotations;
 
 namespace Cle.Compiler
 {
@@ -12,21 +11,18 @@ namespace Cle.Compiler
         /// <summary>
         /// Gets the writable stream for the output executable.
         /// </summary>
-        [CanBeNull]
-        Stream GetExecutableStream();
+        Stream? GetExecutableStream();
 
         /// <summary>
         /// Gets a writer for the output disassembly.
         /// May return null if the file can not be created.
         /// </summary>
-        [CanBeNull]
-        TextWriter GetDisassemblyWriter();
+        TextWriter? GetDisassemblyWriter();
 
         /// <summary>
         /// Gets a debug log writer.
         /// May return null if the file can not be created.
         /// </summary>
-        [CanBeNull]
-        TextWriter GetDebugFileWriter();
+        TextWriter? GetDebugFileWriter();
     }
 }

--- a/src/Cle.Compiler/ISourceFileProvider.cs
+++ b/src/Cle.Compiler/ISourceFileProvider.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using JetBrains.Annotations;
+using System.Runtime.CompilerServices;
 
 namespace Cle.Compiler
 {
@@ -13,7 +13,7 @@ namespace Cle.Compiler
         /// Tries to return a sequence of source file names that compose the specified module.
         /// If the module could not be found, returns false.
         /// </summary>
-        bool TryGetFilenamesForModule([NotNull] string moduleName, [CanBeNull] out IEnumerable<string> filenames);
+        bool TryGetFilenamesForModule(string moduleName, [NotNullWhenTrue] out IEnumerable<string>? filenames);
 
         /// <summary>
         /// Tries to open the specified source file and return its contents as a view of bytes.
@@ -22,6 +22,6 @@ namespace Cle.Compiler
         /// </summary>
         /// <param name="filename">The file to open, originated from <see cref="TryGetFilenamesForModule"/>.</param>
         /// <param name="fileBytes">View of full file bytes.</param>
-        bool TryGetSourceFile([NotNull] string filename, out Memory<byte> fileBytes);
+        bool TryGetSourceFile(string filename, out Memory<byte> fileBytes);
     }
 }

--- a/src/Cle.Compiler/IndexedRandomAccessStore.cs
+++ b/src/Cle.Compiler/IndexedRandomAccessStore.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Cle.Compiler
 {
@@ -12,7 +13,7 @@ namespace Cle.Compiler
     internal class IndexedRandomAccessStore<T> where T : class
     {
         private int _nextIndex;
-        private T[] _array;
+        private T[]? _array;
 
         /// <summary>
         /// Gets the number of reserved indices.
@@ -35,6 +36,7 @@ namespace Cle.Compiler
                 if (_array is null || _array.Length <= index)
                 {
                     ResizeArray();
+                    Debug.Assert(_array is object);
                 }
                 _array[index] = value;
             }

--- a/src/Cle.Compiler/SingleFileDiagnosticSink.cs
+++ b/src/Cle.Compiler/SingleFileDiagnosticSink.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Generic;
 using Cle.Common;
-using JetBrains.Annotations;
-
 namespace Cle.Compiler
 {
     /// <summary>
@@ -15,16 +13,11 @@ namespace Cle.Compiler
         /// </summary>
         public IReadOnlyList<Diagnostic> Diagnostics => _diagnostics;
 
-        [NotNull]
         private string _moduleName = string.Empty;
-
-        [NotNull]
         private string _filename = string.Empty;
-
-        [NotNull, ItemNotNull]
         private readonly List<Diagnostic> _diagnostics = new List<Diagnostic>();
 
-        public void Reset([NotNull] string moduleName, [NotNull] string filename)
+        public void Reset(string moduleName, string filename)
         {
             _moduleName = moduleName;
             _filename = filename;
@@ -36,12 +29,12 @@ namespace Cle.Compiler
             _diagnostics.Add(new Diagnostic(code, position, _filename, _moduleName, null, null));
         }
 
-        public void Add(DiagnosticCode code, TextPosition position, string actual)
+        public void Add(DiagnosticCode code, TextPosition position, string? actual)
         {
             _diagnostics.Add(new Diagnostic(code, position, _filename, _moduleName, actual, null));
         }
 
-        public void Add(DiagnosticCode code, TextPosition position, string actual, string expected)
+        public void Add(DiagnosticCode code, TextPosition position, string? actual, string? expected)
         {
             _diagnostics.Add(new Diagnostic(code, position, _filename, _moduleName, actual, expected));
         }

--- a/src/Cle.Frontend/Cle.Frontend.csproj
+++ b/src/Cle.Frontend/Cle.Frontend.csproj
@@ -1,9 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <AssemblyName>cle</AssemblyName>
   </PropertyGroup>
   

--- a/src/Cle.Frontend/Cle.Frontend.csproj
+++ b/src/Cle.Frontend/Cle.Frontend.csproj
@@ -4,12 +4,12 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <LangVersion>8.0</LangVersion>
+    <NullableContextOptions>enable</NullableContextOptions>
     <AssemblyName>cle</AssemblyName>
   </PropertyGroup>
   
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.3.0" />
-    <PackageReference Include="JetBrains.Annotations" Version="2018.2.1" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Cle.Frontend/CommandLineOptions.cs
+++ b/src/Cle.Frontend/CommandLineOptions.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using CommandLine;
-using JetBrains.Annotations;
 
 namespace Cle.Frontend
 {
@@ -9,19 +8,17 @@ namespace Cle.Frontend
     /// </summary>
     internal class CommandLineOptions
     {
-        [CanBeNull]
         [Option("dump", HelpText = "If specified, compiler debug information for all methods " + 
             "where the name contains the parameter string will be logged to cle-dump.txt. " +
             "Specify * to dump all methods. More complex wildcard syntax is not supported.")]
-        public string DumpRegex { get; set; }
+        public string? DumpRegex { get; set; }
         
         [Option("disasm", HelpText = "If specified, an assembly language listing for the program " +
                                      "will be emitted in the output directory.")]
         public bool Disassembly { get; set; }
 
-        [CanBeNull, ItemNotNull]
         [Value(0, Required = false,
             HelpText = "Main module path relative to current directory.", MetaName = "module")]
-        public IEnumerable<string> MainModule { get; set; }
+        public IEnumerable<string>? MainModule { get; set; }
     }
 }

--- a/src/Cle.Frontend/CommandLineParser.cs
+++ b/src/Cle.Frontend/CommandLineParser.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using System.Runtime.CompilerServices;
 using Cle.Compiler;
 using CommandLine;
-using JetBrains.Annotations;
 
 namespace Cle.Frontend
 {
@@ -19,9 +19,9 @@ namespace Cle.Frontend
         /// <param name="output">A writer for any output such as help.</param>
         /// <param name="options">The parsed compilation options, if successful.</param>
         public static bool TryParseArguments(
-            [NotNull, ItemNotNull] IEnumerable<string> args,
-            [NotNull] TextWriter output,
-            [CanBeNull] out CompilationOptions options)
+            IEnumerable<string> args,
+            TextWriter output,
+            [NotNullWhenTrue] out CompilationOptions? options)
         {
             var parser = new CommandLine.Parser(config =>
             {

--- a/src/Cle.Frontend/OutputFileProvider.cs
+++ b/src/Cle.Frontend/OutputFileProvider.cs
@@ -1,25 +1,24 @@
 ﻿using System;
 using System.IO;
 using Cle.Compiler;
-using JetBrains.Annotations;
 
 namespace Cle.Frontend
 {
     internal class OutputFileProvider : IOutputFileProvider, IDisposable
     {
-        [NotNull] private readonly string _baseDirectory;
-        [NotNull] private readonly string _outputName;
+        private readonly string _baseDirectory;
+        private readonly string _outputName;
 
-        [CanBeNull] private TextWriter _debugWriter;
-        [CanBeNull] private TextWriter _disassemblyWriter;
-        [CanBeNull] private FileStream _executableStream;
+        private TextWriter? _debugWriter;
+        private TextWriter? _disassemblyWriter;
+        private FileStream? _executableStream;
 
         // TODO: Multi-platform support
         private const string PlatformName = "windows-x64";
         private const string ExecutableExtension = ".exe";
         private const string DisassemblyExtension = ".asm";
 
-        public OutputFileProvider([NotNull] string baseDirectory, [NotNull] string outputName)
+        public OutputFileProvider(string baseDirectory, string outputName)
         {
             _baseDirectory = baseDirectory;
             _outputName = outputName;
@@ -32,7 +31,7 @@ namespace Cle.Frontend
             _executableStream?.Dispose();
         }
 
-        public TextWriter GetDebugFileWriter()
+        public TextWriter? GetDebugFileWriter()
         {
             if (_debugWriter is null)
             {
@@ -49,7 +48,7 @@ namespace Cle.Frontend
             return _debugWriter;
         }
 
-        public Stream GetExecutableStream()
+        public Stream? GetExecutableStream()
         {
             if (_executableStream is null)
             {
@@ -68,7 +67,7 @@ namespace Cle.Frontend
             return _executableStream;
         }
 
-        public TextWriter GetDisassemblyWriter()
+        public TextWriter? GetDisassemblyWriter()
         {
             if (_disassemblyWriter is null)
             {

--- a/src/Cle.Frontend/SourceFileProvider.cs
+++ b/src/Cle.Frontend/SourceFileProvider.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using Cle.Compiler;
-using JetBrains.Annotations;
 
 namespace Cle.Frontend
 {
@@ -10,12 +9,12 @@ namespace Cle.Frontend
     {
         private readonly string _mainDirectory;
 
-        public SourceFileProvider([NotNull] string mainDirectory)
+        public SourceFileProvider(string mainDirectory)
         {
             _mainDirectory = mainDirectory;
         }
 
-        public bool TryGetFilenamesForModule(string moduleName, out IEnumerable<string> filenames)
+        public bool TryGetFilenamesForModule(string moduleName, out IEnumerable<string>? filenames)
         {
             // Use absolute paths everywhere
             // TODO: Support for module search paths

--- a/src/Cle.Parser/Cle.Parser.csproj
+++ b/src/Cle.Parser/Cle.Parser.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Cle.Parser/Cle.Parser.csproj
+++ b/src/Cle.Parser/Cle.Parser.csproj
@@ -3,10 +3,10 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
+    <NullableContextOptions>enable</NullableContextOptions>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2018.2.1" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="System.Memory" Version="4.5.1" />
   </ItemGroup>

--- a/src/Cle.Parser/NameParsing.cs
+++ b/src/Cle.Parser/NameParsing.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
-using JetBrains.Annotations;
 
 namespace Cle.Parser
 {
@@ -13,7 +12,7 @@ namespace Cle.Parser
         /// Returns whether the given namespace name, possibly composed of multiple parts, is valid.
         /// </summary>
         /// <param name="name">The namespace name to check as an UTF-16 string.</param>
-        public static bool IsValidNamespaceName([NotNull] string name)
+        public static bool IsValidNamespaceName(string name)
         {
             // Namespace names must conform to rules for other identifiers, so
             // this check is equivalent to validating a fully qualified name.
@@ -35,7 +34,7 @@ namespace Cle.Parser
         /// Returns whether the given fully qualified (or unqualified) name is valid.
         /// </summary>
         /// <param name="name">The name to check as an UTF-16 string.</param>
-        public static bool IsValidFullName([NotNull] string name)
+        public static bool IsValidFullName(string name)
         {
             return IsValidFullName(name.AsSpan());
         }
@@ -90,7 +89,7 @@ namespace Cle.Parser
         /// to be done by the lexer.
         /// </summary>
         /// <param name="name">The simple name to check as an UTF-16 string.</param>
-        public static bool IsValidSimpleName([NotNull] string name)
+        public static bool IsValidSimpleName(string name)
         {
             return IsValidSimpleName(name.AsSpan());
         }
@@ -126,7 +125,7 @@ namespace Cle.Parser
         /// Returns whether the given name is equal to a reserved type name.
         /// </summary>
         /// <param name="name">The name to check. This may be a simple or a fully qualified name.</param>
-        public static bool IsReservedTypeName([NotNull] string name)
+        public static bool IsReservedTypeName(string name)
         {
             // TODO: More types once they exist (consider matching on the initial part of the name for [u]int[NN])
             return name == "bool" || name == "int32" || name == "void";

--- a/src/Cle.Parser/SyntaxParser.cs
+++ b/src/Cle.Parser/SyntaxParser.cs
@@ -2,10 +2,10 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Cle.Common;
 using Cle.Parser.SyntaxTree;
-using JetBrains.Annotations;
 
 namespace Cle.Parser
 {
@@ -14,15 +14,15 @@ namespace Cle.Parser
     /// </summary>
     public class SyntaxParser
     {
-        [NotNull] private readonly Lexer _lexer;
-        [NotNull] private readonly string _filename;
-        [NotNull] private readonly IDiagnosticSink _diagnosticSink;
+        private readonly Lexer _lexer;
+        private readonly string _filename;
+        private readonly IDiagnosticSink _diagnosticSink;
 
         /// <summary>
         /// Internal for testing only.
         /// Use <see cref="Parse"/> instead.
         /// </summary>
-        internal SyntaxParser(Memory<byte> source, [NotNull] string filename, [NotNull] IDiagnosticSink diagnosticSink)
+        internal SyntaxParser(Memory<byte> source, string filename, IDiagnosticSink diagnosticSink)
         {
             _lexer = new Lexer(source);
             _filename = filename;
@@ -36,18 +36,16 @@ namespace Cle.Parser
         /// <param name="source">The UTF-8 encoded source file content.</param>
         /// <param name="filename">The name of the source file.</param>
         /// <param name="diagnosticSink">The sink to write parse diagnostics into.</param>
-        [CanBeNull]
-        public static SourceFileSyntax Parse(
+        public static SourceFileSyntax? Parse(
             Memory<byte> source, 
-            [NotNull] string filename,
-            [NotNull] IDiagnosticSink diagnosticSink)
+            string filename,
+            IDiagnosticSink diagnosticSink)
         {
             var parser = new SyntaxParser(source, filename, diagnosticSink);
             return parser.ParseSourceFile();
         }
 
-        [CanBeNull]
-        private SourceFileSyntax ParseSourceFile()
+        private SourceFileSyntax? ParseSourceFile()
         {
             var namespaceName = string.Empty;
             var functionListBuilder = ImmutableList<FunctionSyntax>.Empty.ToBuilder();
@@ -165,7 +163,7 @@ namespace Cle.Parser
             return new SourceFileSyntax(namespaceName, _filename, functionListBuilder.ToImmutable());
         }
 
-        private bool TryParseAttribute([CanBeNull] out AttributeSyntax attribute)
+        private bool TryParseAttribute([NotNullWhenTrue] out AttributeSyntax? attribute)
         {
             attribute = null;
 
@@ -190,10 +188,8 @@ namespace Cle.Parser
             return true;
         }
 
-        private bool TryParseNamespaceDeclaration([NotNull] out string namespaceName)
+        private bool TryParseNamespaceDeclaration(out string namespaceName)
         {
-            namespaceName = string.Empty;
-
             // Eat the 'namespace' token
             EatAndAssertToken(TokenType.Namespace);
 
@@ -217,7 +213,7 @@ namespace Cle.Parser
             return true;
         }
 
-        private bool TryParseParameterList([NotNull, ItemNotNull] out ImmutableList<ParameterDeclarationSyntax> parameters)
+        private bool TryParseParameterList(out ImmutableList<ParameterDeclarationSyntax> parameters)
         {
             parameters = ImmutableList<ParameterDeclarationSyntax>.Empty;
 
@@ -278,7 +274,7 @@ namespace Cle.Parser
             return true;
         }
         
-        private bool TryParseBlock([CanBeNull] out BlockSyntax block)
+        private bool TryParseBlock([NotNullWhenTrue] out BlockSyntax? block)
         {
             block = null;
 
@@ -363,7 +359,7 @@ namespace Cle.Parser
             return true;
         }
 
-        private bool TryParseIf([CanBeNull] out IfStatementSyntax ifStatement)
+        private bool TryParseIf([NotNullWhenTrue] out IfStatementSyntax? ifStatement)
         {
             ifStatement = null;
 
@@ -430,7 +426,7 @@ namespace Cle.Parser
             }
         }
 
-        private bool TryParseReturnStatement([CanBeNull] out ReturnStatementSyntax returnStatement)
+        private bool TryParseReturnStatement([NotNullWhenTrue] out ReturnStatementSyntax? returnStatement)
         {
             returnStatement = null;
 
@@ -440,7 +436,7 @@ namespace Cle.Parser
             // There are two kinds of returns: void return and value return.
             // In case of the former, the keyword is immediately followed by a semicolon.
             // In case of the latter, parse the expression.
-            ExpressionSyntax expression = null;
+            ExpressionSyntax? expression = null;
             if (_lexer.PeekTokenType() != TokenType.Semicolon)
             {
                 if (!TryParseExpression(out expression))
@@ -459,7 +455,7 @@ namespace Cle.Parser
             return true;
         }
 
-        private bool TryParseWhileStatement([CanBeNull] out WhileStatementSyntax whileStatement)
+        private bool TryParseWhileStatement([NotNullWhenTrue] out WhileStatementSyntax? whileStatement)
         {
             whileStatement = null;
 
@@ -489,7 +485,7 @@ namespace Cle.Parser
             return true;
         }
 
-        private bool TryParseCondition([CanBeNull] out ExpressionSyntax condition)
+        private bool TryParseCondition([NotNullWhenTrue] out ExpressionSyntax? condition)
         {
             if (!ExpectToken(TokenType.OpenParen, DiagnosticCode.ExpectedCondition) ||
                 !TryParseExpression(out condition) ||
@@ -502,7 +498,7 @@ namespace Cle.Parser
             return true;
         }
 
-        private bool TryParseStatementStartingWithIdentifier(out StatementSyntax statement)
+        private bool TryParseStatementStartingWithIdentifier([NotNullWhenTrue] out StatementSyntax? statement)
         {
             // This method handles
             //   - variable declarations ("int32 name = expression;")
@@ -592,12 +588,12 @@ namespace Cle.Parser
         /// Internal for testing only.
         /// This function handles error logging on its own.
         /// </summary>
-        internal bool TryParseExpression([CanBeNull] out ExpressionSyntax expressionSyntax)
+        internal bool TryParseExpression([NotNullWhenTrue] out ExpressionSyntax? expressionSyntax)
         {
             return TryParseLogicalExpression(out expressionSyntax);
         }
 
-        private bool TryParseLogicalExpression([CanBeNull] out ExpressionSyntax expressionSyntax)
+        private bool TryParseLogicalExpression([NotNullWhenTrue] out ExpressionSyntax? expressionSyntax)
         {
             // Logical expression := Logical expression [& && | || ^] Relational expression
             expressionSyntax = null;
@@ -658,7 +654,7 @@ namespace Cle.Parser
             }
         }
 
-        private bool TryParseRelationalExpression([CanBeNull] out ExpressionSyntax expressionSyntax)
+        private bool TryParseRelationalExpression([NotNullWhenTrue] out ExpressionSyntax? expressionSyntax)
         {
             // Relational expression := Relational expression [== != < <= >= >] Shift expression
             expressionSyntax = null;
@@ -723,7 +719,7 @@ namespace Cle.Parser
             }
         }
 
-        private bool TryParseShiftExpression([CanBeNull] out ExpressionSyntax expressionSyntax)
+        private bool TryParseShiftExpression([NotNullWhenTrue] out ExpressionSyntax? expressionSyntax)
         {
             // Shift expression := Shift expression [<< >>] Arithmetic expression
             expressionSyntax = null;
@@ -777,7 +773,7 @@ namespace Cle.Parser
             }
         }
 
-        private bool TryParseArithmeticExpression([CanBeNull] out ExpressionSyntax expressionSyntax)
+        private bool TryParseArithmeticExpression([NotNullWhenTrue] out ExpressionSyntax? expressionSyntax)
         {
             // Arithmetic expression := Arithmetic expression [+ -] Term
             expressionSyntax = null;
@@ -830,7 +826,7 @@ namespace Cle.Parser
             }
         }
 
-        private bool TryParseTerm([CanBeNull] out ExpressionSyntax expressionSyntax)
+        private bool TryParseTerm([NotNullWhenTrue] out ExpressionSyntax? expressionSyntax)
         {
             // Term := Term [* / %] Factor
             expressionSyntax = null;
@@ -886,7 +882,7 @@ namespace Cle.Parser
             }
         }
 
-        private bool TryParseFactor([CanBeNull] out ExpressionSyntax expressionSyntax)
+        private bool TryParseFactor([NotNullWhenTrue] out ExpressionSyntax? expressionSyntax)
         {
             // Factor := Identifier | Number | Boolean literal | ( Expression ) | -Factor | !Factor | ~Factor
             
@@ -967,7 +963,7 @@ namespace Cle.Parser
             }
 
             // Local helper method for sharing code between the various unary paths
-            bool ParseUnary(UnaryOperation op, out ExpressionSyntax syntax)
+            bool ParseUnary(UnaryOperation op, out ExpressionSyntax? syntax)
             {
                 // Eat the operator
                 var opPosition = _lexer.Position;
@@ -988,7 +984,7 @@ namespace Cle.Parser
             }
         }
 
-        private bool TryParseNumber([CanBeNull] out ExpressionSyntax literalSyntax)
+        private bool TryParseNumber([NotNullWhenTrue] out ExpressionSyntax? literalSyntax)
         {
             literalSyntax = null;
 
@@ -1018,7 +1014,7 @@ namespace Cle.Parser
         /// This function assumes that the function name, passed in <paramref name="functionName"/>,
         /// has already been read from the lexer, and the next token is known to be "(".
         /// </summary>
-        private bool TryParseFunctionCall([NotNull] string functionName, [CanBeNull] out FunctionCallSyntax callSyntax)
+        private bool TryParseFunctionCall(string functionName, [NotNullWhenTrue] out FunctionCallSyntax? callSyntax)
         {
             callSyntax = null;
             var callPosition = _lexer.LastPosition;
@@ -1130,7 +1126,7 @@ namespace Cle.Parser
         /// </summary>
         /// <param name="errorCode">The error code to log if the token is not an identifier.</param>
         /// <param name="identifier">The read identifier.</param>
-        private bool ExpectIdentifier(DiagnosticCode errorCode, [NotNull] out string identifier)
+        private bool ExpectIdentifier(DiagnosticCode errorCode, out string identifier)
         {
             if (_lexer.PeekTokenType() == TokenType.Identifier)
             {
@@ -1148,7 +1144,6 @@ namespace Cle.Parser
         /// <summary>
         /// Reads a token and converts it into an UTF-16 string.
         /// </summary>
-        [NotNull]
         private string ReadTokenIntoString()
         {
             // TODO: Remove ToArray() once the ReadOnlySpan<byte> overload is available

--- a/src/Cle.Parser/SyntaxTree/AssignmentSyntax.cs
+++ b/src/Cle.Parser/SyntaxTree/AssignmentSyntax.cs
@@ -1,5 +1,4 @@
 ﻿using Cle.Common;
-using JetBrains.Annotations;
 
 namespace Cle.Parser.SyntaxTree
 {
@@ -11,18 +10,16 @@ namespace Cle.Parser.SyntaxTree
         /// <summary>
         /// Gets the name of the variable.
         /// </summary>
-        [NotNull]
         public string Variable { get; }
 
         /// <summary>
         /// Gets the new value of the variable.
         /// </summary>
-        [NotNull]
         public ExpressionSyntax Value { get; }
 
         public AssignmentSyntax(
-            [NotNull] string variable,
-            [NotNull] ExpressionSyntax value,
+            string variable,
+            ExpressionSyntax value,
             TextPosition position)
             : base(position)
         {

--- a/src/Cle.Parser/SyntaxTree/AttributeSyntax.cs
+++ b/src/Cle.Parser/SyntaxTree/AttributeSyntax.cs
@@ -1,5 +1,4 @@
 ﻿using Cle.Common;
-using JetBrains.Annotations;
 
 namespace Cle.Parser.SyntaxTree
 {
@@ -11,11 +10,10 @@ namespace Cle.Parser.SyntaxTree
         /// <summary>
         /// Gets the name of the attribute.
         /// </summary>
-        [NotNull]
         public string Name { get; }
 
         public AttributeSyntax(
-            [NotNull] string name,
+            string name,
             TextPosition position)
             : base(position)
         {

--- a/src/Cle.Parser/SyntaxTree/BinaryExpressionSyntax.cs
+++ b/src/Cle.Parser/SyntaxTree/BinaryExpressionSyntax.cs
@@ -1,5 +1,4 @@
 ﻿using Cle.Common;
-using JetBrains.Annotations;
 
 namespace Cle.Parser.SyntaxTree
 {
@@ -43,18 +42,16 @@ namespace Cle.Parser.SyntaxTree
         /// Gets the left parameter to the binary operation.
         /// This parameter should be evaluated first.
         /// </summary>
-        [NotNull]
         public ExpressionSyntax Left { get; }
 
         /// <summary>
         /// Gets the right parameter to the binary operation.
         /// This parameter should be evaluated after <see cref="Left"/>.
         /// </summary>
-        [NotNull]
         public ExpressionSyntax Right { get; }
 
-        public BinaryExpressionSyntax(BinaryOperation operation, [NotNull] ExpressionSyntax left,
-            [NotNull] ExpressionSyntax right, TextPosition position)
+        public BinaryExpressionSyntax(BinaryOperation operation, ExpressionSyntax left,
+            ExpressionSyntax right, TextPosition position)
             : base(position)
         {
             Operation = operation;

--- a/src/Cle.Parser/SyntaxTree/BlockSyntax.cs
+++ b/src/Cle.Parser/SyntaxTree/BlockSyntax.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Immutable;
 using Cle.Common;
-using JetBrains.Annotations;
 
 namespace Cle.Parser.SyntaxTree
 {
@@ -12,11 +11,10 @@ namespace Cle.Parser.SyntaxTree
         /// <summary>
         /// Gets the ordered list of statements within this block.
         /// </summary>
-        [NotNull, ItemNotNull]
         public ImmutableList<StatementSyntax> Statements { get; }
 
         public BlockSyntax(
-            [NotNull, ItemNotNull] ImmutableList<StatementSyntax> statements,
+            ImmutableList<StatementSyntax> statements,
             TextPosition position)
             : base(position)
         {

--- a/src/Cle.Parser/SyntaxTree/FunctionCallStatementSyntax.cs
+++ b/src/Cle.Parser/SyntaxTree/FunctionCallStatementSyntax.cs
@@ -1,5 +1,4 @@
 ﻿using Cle.Common;
-using JetBrains.Annotations;
 
 namespace Cle.Parser.SyntaxTree
 {
@@ -12,11 +11,10 @@ namespace Cle.Parser.SyntaxTree
         /// <summary>
         /// Gets the proper function call expression.
         /// </summary>
-        [NotNull]
         public FunctionCallSyntax Call { get; }
 
         public FunctionCallStatementSyntax(
-            [NotNull] FunctionCallSyntax call,
+            FunctionCallSyntax call,
             TextPosition position)
             : base(position)
         {

--- a/src/Cle.Parser/SyntaxTree/FunctionCallSyntax.cs
+++ b/src/Cle.Parser/SyntaxTree/FunctionCallSyntax.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Immutable;
 using Cle.Common;
-using JetBrains.Annotations;
 
 namespace Cle.Parser.SyntaxTree
 {
@@ -12,18 +11,15 @@ namespace Cle.Parser.SyntaxTree
         /// <summary>
         /// Gets the name of the called function.
         /// </summary>
-        [NotNull]
         public string Function { get; }
 
         /// <summary>
         /// Gets the parameters in order.
         /// </summary>
-        [NotNull]
-        [ItemNotNull]
         public ImmutableList<ExpressionSyntax> Parameters { get; }
 
-        public FunctionCallSyntax([NotNull] string function,
-            [NotNull, ItemNotNull] ImmutableList<ExpressionSyntax> parameters, TextPosition position)
+        public FunctionCallSyntax(string function,
+            ImmutableList<ExpressionSyntax> parameters, TextPosition position)
             : base(position)
         {
             Function = function;

--- a/src/Cle.Parser/SyntaxTree/FunctionSyntax.cs
+++ b/src/Cle.Parser/SyntaxTree/FunctionSyntax.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Immutable;
 using Cle.Common;
-using JetBrains.Annotations;
 
 namespace Cle.Parser.SyntaxTree
 {
@@ -13,7 +12,6 @@ namespace Cle.Parser.SyntaxTree
         /// Gets the simple name of this function.
         /// The name is guaranteed to be syntactically valid, but it may be semantically invalid.
         /// </summary>
-        [NotNull]
         public string Name { get; }
 
         /// <summary>
@@ -25,37 +23,31 @@ namespace Cle.Parser.SyntaxTree
         /// Gets the declared return type of this function.
         /// The type name may be full or simple and the type might not exist.
         /// </summary>
-        [NotNull]
         public string ReturnTypeName { get; }
 
         /// <summary>
         /// Gets the parameter list of this function.
         /// </summary>
-        [NotNull]
-        [ItemNotNull]
         public ImmutableList<ParameterDeclarationSyntax> Parameters { get; }
 
         /// <summary>
         /// Gets the list of attributes applied to this function.
         /// The list may be empty.
         /// </summary>
-        [NotNull]
-        [ItemNotNull]
         public ImmutableList<AttributeSyntax> Attributes { get; }
 
         /// <summary>
         /// Gets the code block of this function.
         /// </summary>
-        [NotNull]
         public BlockSyntax Block { get; }
 
         public FunctionSyntax(
-            [NotNull] string name,
-            [NotNull] string returnType,
+            string name,
+            string returnType,
             Visibility visibility,
-            [NotNull, ItemNotNull] ImmutableList<ParameterDeclarationSyntax> parameters,
-            [NotNull, ItemNotNull] ImmutableList<AttributeSyntax> attributes,
-            [NotNull] BlockSyntax block,
+            ImmutableList<ParameterDeclarationSyntax> parameters,
+            ImmutableList<AttributeSyntax> attributes,
+            BlockSyntax block,
             TextPosition position)
             : base(position)
         {

--- a/src/Cle.Parser/SyntaxTree/IfStatementSyntax.cs
+++ b/src/Cle.Parser/SyntaxTree/IfStatementSyntax.cs
@@ -1,5 +1,4 @@
 ﻿using Cle.Common;
-using JetBrains.Annotations;
 
 namespace Cle.Parser.SyntaxTree
 {
@@ -11,13 +10,11 @@ namespace Cle.Parser.SyntaxTree
         /// <summary>
         /// Gets the condition expression.
         /// </summary>
-        [NotNull]
         public ExpressionSyntax ConditionSyntax { get; }
 
         /// <summary>
         /// Gets the block that will be executed when the condition is true.
         /// </summary>
-        [NotNull]
         public BlockSyntax ThenBlockSyntax { get; }
 
         /// <summary>
@@ -27,13 +24,12 @@ namespace Cle.Parser.SyntaxTree
         ///  - BlockSyntax, if there is an 'else' block,
         ///  - IfStatementSyntax, if there is an 'else if' statement.
         /// </summary>
-        [CanBeNull]
-        public StatementSyntax ElseSyntax { get; }
+        public StatementSyntax? ElseSyntax { get; }
 
         public IfStatementSyntax(
-            [NotNull] ExpressionSyntax condition,
-            [NotNull] BlockSyntax thenBlock,
-            [CanBeNull] StatementSyntax elseSyntax,
+            ExpressionSyntax condition,
+            BlockSyntax thenBlock,
+            StatementSyntax? elseSyntax,
             TextPosition position)
             : base(position)
         {

--- a/src/Cle.Parser/SyntaxTree/NamedValueSyntax.cs
+++ b/src/Cle.Parser/SyntaxTree/NamedValueSyntax.cs
@@ -1,5 +1,4 @@
 ﻿using Cle.Common;
-using JetBrains.Annotations;
 
 namespace Cle.Parser.SyntaxTree
 {
@@ -11,10 +10,9 @@ namespace Cle.Parser.SyntaxTree
         /// <summary>
         /// Gets the referenced variable/constant name.
         /// </summary>
-        [NotNull]
         public string Name { get; }
 
-        public NamedValueSyntax([NotNull] string name, TextPosition position)
+        public NamedValueSyntax(string name, TextPosition position)
             : base(position)
         {
             Name = name;

--- a/src/Cle.Parser/SyntaxTree/ParameterDeclarationSyntax.cs
+++ b/src/Cle.Parser/SyntaxTree/ParameterDeclarationSyntax.cs
@@ -1,5 +1,4 @@
 ﻿using Cle.Common;
-using JetBrains.Annotations;
 
 namespace Cle.Parser.SyntaxTree
 {
@@ -11,18 +10,16 @@ namespace Cle.Parser.SyntaxTree
         /// <summary>
         /// Gets the declared type of the parameter.
         /// </summary>
-        [NotNull]
         public string TypeName { get; }
 
         /// <summary>
         /// Gets the name of the parameter.
         /// </summary>
-        [NotNull]
         public string Name { get; }
 
         public ParameterDeclarationSyntax(
-            [NotNull] string typeName,
-            [NotNull] string name,
+            string typeName,
+            string name,
             TextPosition position)
             : base(position)
         {

--- a/src/Cle.Parser/SyntaxTree/ReturnStatementSyntax.cs
+++ b/src/Cle.Parser/SyntaxTree/ReturnStatementSyntax.cs
@@ -1,5 +1,4 @@
 ﻿using Cle.Common;
-using JetBrains.Annotations;
 
 namespace Cle.Parser.SyntaxTree
 {
@@ -12,11 +11,10 @@ namespace Cle.Parser.SyntaxTree
         /// Gets the expression that is returned.
         /// Null for void returns.
         /// </summary>
-        [CanBeNull]
-        public ExpressionSyntax ResultExpression { get; }
+        public ExpressionSyntax? ResultExpression { get; }
 
         public ReturnStatementSyntax(
-            [CanBeNull] ExpressionSyntax expression,
+            ExpressionSyntax? expression,
             TextPosition position)
             : base(position)
         {

--- a/src/Cle.Parser/SyntaxTree/SourceFileSyntax.cs
+++ b/src/Cle.Parser/SyntaxTree/SourceFileSyntax.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Immutable;
-using JetBrains.Annotations;
 
 namespace Cle.Parser.SyntaxTree
 {
@@ -11,26 +10,22 @@ namespace Cle.Parser.SyntaxTree
         /// <summary>
         /// Gets the namespace name declared in this source file.
         /// </summary>
-        [NotNull]
         public string Namespace { get; }
 
         /// <summary>
         /// Gets the source file name.
         /// </summary>
-        [NotNull]
         public string Filename { get; }
 
         /// <summary>
         /// Gets the global functions declared in this source file.
         /// </summary>
-        [NotNull]
-        [ItemNotNull]
         public ImmutableList<FunctionSyntax> Functions { get; }
 
         public SourceFileSyntax(
-            [NotNull] string namespaceName,
-            [NotNull] string filename,
-            [NotNull, ItemNotNull] ImmutableList<FunctionSyntax> functions)
+            string namespaceName,
+            string filename,
+            ImmutableList<FunctionSyntax> functions)
         {
             Namespace = namespaceName;
             Filename = filename;

--- a/src/Cle.Parser/SyntaxTree/UnaryExpressionSyntax.cs
+++ b/src/Cle.Parser/SyntaxTree/UnaryExpressionSyntax.cs
@@ -1,5 +1,4 @@
 ﻿using Cle.Common;
-using JetBrains.Annotations;
 
 namespace Cle.Parser.SyntaxTree
 {
@@ -27,10 +26,9 @@ namespace Cle.Parser.SyntaxTree
         /// <summary>
         /// Gets the parameter to the unary operation.
         /// </summary>
-        [NotNull]
         public ExpressionSyntax InnerExpression { get; }
 
-        public UnaryExpressionSyntax(UnaryOperation operation, [NotNull] ExpressionSyntax innerExpression,
+        public UnaryExpressionSyntax(UnaryOperation operation, ExpressionSyntax innerExpression,
             TextPosition position)
             : base(position)
         {

--- a/src/Cle.Parser/SyntaxTree/VariableDeclarationSyntax.cs
+++ b/src/Cle.Parser/SyntaxTree/VariableDeclarationSyntax.cs
@@ -1,5 +1,4 @@
 ﻿using Cle.Common;
-using JetBrains.Annotations;
 
 namespace Cle.Parser.SyntaxTree
 {
@@ -11,25 +10,22 @@ namespace Cle.Parser.SyntaxTree
         /// <summary>
         /// Gets the declared type of the variable.
         /// </summary>
-        [NotNull]
         public string TypeName { get; }
 
         /// <summary>
         /// Gets the name of the variable.
         /// </summary>
-        [NotNull]
         public string Name { get; }
 
         /// <summary>
         /// Gets the initial value of the variable.
         /// </summary>
-        [NotNull]
         public ExpressionSyntax InitialValueExpression { get; }
 
         public VariableDeclarationSyntax(
-            [NotNull] string typeName,
-            [NotNull] string name,
-            [NotNull] ExpressionSyntax initialValue,
+            string typeName,
+            string name,
+            ExpressionSyntax initialValue,
             TextPosition position)
             : base(position)
         {

--- a/src/Cle.Parser/SyntaxTree/WhileStatementSyntax.cs
+++ b/src/Cle.Parser/SyntaxTree/WhileStatementSyntax.cs
@@ -1,5 +1,4 @@
 ﻿using Cle.Common;
-using JetBrains.Annotations;
 
 namespace Cle.Parser.SyntaxTree
 {
@@ -11,18 +10,16 @@ namespace Cle.Parser.SyntaxTree
         /// <summary>
         /// Gets the condition expression.
         /// </summary>
-        [NotNull]
         public ExpressionSyntax ConditionSyntax { get; }
 
         /// <summary>
         /// Gets the block that will be executed while the condition is true.
         /// </summary>
-        [NotNull]
         public BlockSyntax BodySyntax { get; }
 
         public WhileStatementSyntax(
-            [NotNull] ExpressionSyntax condition,
-            [NotNull] BlockSyntax body,
+            ExpressionSyntax condition,
+            BlockSyntax body,
             TextPosition position)
             : base(position)
         {

--- a/src/Cle.SemanticAnalysis/Cle.SemanticAnalysis.csproj
+++ b/src/Cle.SemanticAnalysis/Cle.SemanticAnalysis.csproj
@@ -3,10 +3,10 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
+    <NullableContextOptions>enable</NullableContextOptions>
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2018.2.1" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="System.Memory" Version="4.5.1" />
   </ItemGroup>

--- a/src/Cle.SemanticAnalysis/Cle.SemanticAnalysis.csproj
+++ b/src/Cle.SemanticAnalysis/Cle.SemanticAnalysis.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Cle.SemanticAnalysis/ExpressionCompiler.cs
+++ b/src/Cle.SemanticAnalysis/ExpressionCompiler.cs
@@ -3,7 +3,6 @@ using Cle.Common;
 using Cle.Common.TypeSystem;
 using Cle.Parser.SyntaxTree;
 using Cle.SemanticAnalysis.IR;
-using JetBrains.Annotations;
 
 namespace Cle.SemanticAnalysis
 {
@@ -26,12 +25,12 @@ namespace Cle.SemanticAnalysis
         /// <param name="nameResolver">The resolver for variable and method names.</param>
         /// <param name="diagnostics">Receiver for possible diagnostics.</param>
         public static int TryCompileExpression(
-            [NotNull] ExpressionSyntax syntax,
-            [CanBeNull] TypeDefinition expectedType,
-            [NotNull] CompiledMethod method,
-            [NotNull] BasicBlockBuilder builder,
-            [NotNull] INameResolver nameResolver,
-            [NotNull] IDiagnosticSink diagnostics)
+            ExpressionSyntax syntax,
+            TypeDefinition? expectedType,
+            CompiledMethod method,
+            BasicBlockBuilder builder,
+            INameResolver nameResolver,
+            IDiagnosticSink diagnostics)
         {
             // Compile the expression
             if (!InternalTryCompileExpression(syntax, method, builder, nameResolver, diagnostics, out var value))
@@ -65,11 +64,11 @@ namespace Cle.SemanticAnalysis
         }
 
         private static bool InternalTryCompileExpression(
-            [NotNull] ExpressionSyntax syntax,
-            [NotNull] CompiledMethod method,
-            [NotNull] BasicBlockBuilder builder,
-            [NotNull] INameResolver nameResolver,
-            [NotNull] IDiagnosticSink diagnostics,
+            ExpressionSyntax syntax,
+            CompiledMethod method,
+            BasicBlockBuilder builder,
+            INameResolver nameResolver,
+            IDiagnosticSink diagnostics,
             out Temporary value)
         {
             value = default;

--- a/src/Cle.SemanticAnalysis/IDeclarationProvider.cs
+++ b/src/Cle.SemanticAnalysis/IDeclarationProvider.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using JetBrains.Annotations;
 
 namespace Cle.SemanticAnalysis
 {
@@ -15,10 +14,9 @@ namespace Cle.SemanticAnalysis
         /// <param name="visibleNamespaces">Namespaces available for searching the method.</param>
         /// <param name="sourceFile">The current source file, used for matching private methods.</param>
         // TODO: Specifying visible modules
-        [NotNull, ItemNotNull]
         IReadOnlyList<MethodDeclaration> GetMethodDeclarations(
-            [NotNull] string methodName,
-            [NotNull, ItemNotNull] IReadOnlyList<string> visibleNamespaces,
-            [NotNull] string sourceFile);
+            string methodName,
+            IReadOnlyList<string> visibleNamespaces,
+            string sourceFile);
     }
 }

--- a/src/Cle.SemanticAnalysis/INameResolver.cs
+++ b/src/Cle.SemanticAnalysis/INameResolver.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using JetBrains.Annotations;
 
 namespace Cle.SemanticAnalysis
 {
@@ -12,14 +11,13 @@ namespace Cle.SemanticAnalysis
         /// Gets all matching method declarations for the given method name.
         /// </summary>
         /// <param name="name">Either a full or simple method name.</param>
-        [NotNull, ItemNotNull]
-        IReadOnlyList<MethodDeclaration> ResolveMethod([NotNull] string name);
+        IReadOnlyList<MethodDeclaration> ResolveMethod(string name);
 
         /// <summary>
         /// Tries to get the local index for the given variable.
         /// </summary>
         /// <param name="name">The variable name.</param>
         /// <param name="localIndex">If the variable was found, its local index.</param>
-        bool TryResolveVariable([NotNull] string name, out int localIndex);
+        bool TryResolveVariable(string name, out int localIndex);
     }
 }

--- a/src/Cle.SemanticAnalysis/IR/BasicBlock.cs
+++ b/src/Cle.SemanticAnalysis/IR/BasicBlock.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Immutable;
-using JetBrains.Annotations;
 
 namespace Cle.SemanticAnalysis.IR
 {
@@ -11,13 +10,11 @@ namespace Cle.SemanticAnalysis.IR
         /// <summary>
         /// Gets the immutable linear list of instructions.
         /// </summary>
-        [NotNull]
         public ImmutableList<Instruction> Instructions { get; }
 
         /// <summary>
         /// Gets the Phi nodes in this basic block.
         /// </summary>
-        [NotNull]
         public ImmutableList<Phi> Phis { get; }
 
         /// <summary>
@@ -36,13 +33,12 @@ namespace Cle.SemanticAnalysis.IR
         /// <summary>
         /// Gets the predecessors of this basic block in an arbitrary order.
         /// </summary>
-        [NotNull]
         public ImmutableList<int> Predecessors { get; }
 
-        public BasicBlock([NotNull] ImmutableList<Instruction> instructions,
-            [NotNull] ImmutableList<Phi> phis,
+        public BasicBlock(ImmutableList<Instruction> instructions,
+            ImmutableList<Phi> phis,
             int defaultSuccessor, int alternativeSuccessor,
-            [NotNull] ImmutableList<int> predecessors)
+            ImmutableList<int> predecessors)
         {
             Instructions = instructions;
             Phis = phis;

--- a/src/Cle.SemanticAnalysis/IR/BasicBlockBuilder.cs
+++ b/src/Cle.SemanticAnalysis/IR/BasicBlockBuilder.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Immutable;
-using JetBrains.Annotations;
 
 namespace Cle.SemanticAnalysis.IR
 {
@@ -11,10 +10,8 @@ namespace Cle.SemanticAnalysis.IR
     /// </summary>
     public class BasicBlockBuilder
     {
-        [NotNull]
         internal ImmutableList<Instruction>.Builder Instructions { get; } = ImmutableList<Instruction>.Empty.ToBuilder();
 
-        [NotNull]
         internal ImmutableList<Phi>.Builder Phis { get; } = ImmutableList<Phi>.Empty.ToBuilder();
 
         /// <summary>
@@ -63,10 +60,9 @@ namespace Cle.SemanticAnalysis.IR
             }
         }
 
-        [NotNull]
         private readonly BasicBlockGraphBuilder _parent;
 
-        internal BasicBlockBuilder([NotNull] BasicBlockGraphBuilder parent, int index)
+        internal BasicBlockBuilder(BasicBlockGraphBuilder parent, int index)
         {
             _parent = parent;
             Index = index;
@@ -89,7 +85,7 @@ namespace Cle.SemanticAnalysis.IR
         /// </summary>
         /// <param name="destination">The local that will receive the merged value from the Phi.</param>
         /// <param name="operands">The operand locals to the Phi.</param>
-        public void AddPhi(int destination, [NotNull] ImmutableList<int> operands)
+        public void AddPhi(int destination, ImmutableList<int> operands)
         {
             Phis.Add(new Phi(destination, operands));
         }

--- a/src/Cle.SemanticAnalysis/IR/BasicBlockGraph.cs
+++ b/src/Cle.SemanticAnalysis/IR/BasicBlockGraph.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Immutable;
-using JetBrains.Annotations;
 
 namespace Cle.SemanticAnalysis.IR
 {
@@ -8,11 +7,9 @@ namespace Cle.SemanticAnalysis.IR
     /// </summary>
     public class BasicBlockGraph
     {
-        [NotNull]
-        [ItemCanBeNull]
-        public readonly ImmutableList<BasicBlock> BasicBlocks;
+        public readonly ImmutableList<BasicBlock?> BasicBlocks;
 
-        public BasicBlockGraph([NotNull, ItemCanBeNull] ImmutableList<BasicBlock> basicBlocks)
+        public BasicBlockGraph(ImmutableList<BasicBlock?> basicBlocks)
         {
             BasicBlocks = basicBlocks;
         }

--- a/src/Cle.SemanticAnalysis/IR/BasicBlockGraphBuilder.cs
+++ b/src/Cle.SemanticAnalysis/IR/BasicBlockGraphBuilder.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using JetBrains.Annotations;
 
 namespace Cle.SemanticAnalysis.IR
 {
@@ -12,8 +11,6 @@ namespace Cle.SemanticAnalysis.IR
     /// </summary>
     public class BasicBlockGraphBuilder
     {
-        [NotNull]
-        [ItemNotNull]
         private readonly List<BasicBlockBuilder> _builders = new List<BasicBlockBuilder>();
 
         /// <summary>
@@ -43,7 +40,6 @@ namespace Cle.SemanticAnalysis.IR
         /// Gets the basic block builder associated with the specified index.
         /// The builder must already be created.
         /// </summary>
-        [NotNull]
         public BasicBlockBuilder GetBuilderByBlockIndex(int blockIndex)
         {
             return _builders[blockIndex];
@@ -70,7 +66,7 @@ namespace Cle.SemanticAnalysis.IR
             MarkBlock(0, liveBlocks, predecessors);
 
             // Construct each marked basic block
-            var blocks = ImmutableList<BasicBlock>.Empty.ToBuilder();
+            var blocks = ImmutableList<BasicBlock?>.Empty.ToBuilder();
             for (var i = 0; i < _builders.Count; i++)
             {
                 // Skip unreachable blocks but append null to preserve indexing

--- a/src/Cle.SemanticAnalysis/IR/CompiledMethod.cs
+++ b/src/Cle.SemanticAnalysis/IR/CompiledMethod.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using Cle.Common.TypeSystem;
-using JetBrains.Annotations;
 
 namespace Cle.SemanticAnalysis.IR
 {
@@ -15,33 +14,29 @@ namespace Cle.SemanticAnalysis.IR
         /// Gets the full name of this method.
         /// This can be used for debugging and emitting symbols.
         /// </summary>
-        [NotNull]
         public string FullName { get; }
 
         /// <summary>
         /// Gets or sets the basic block graph for this method.
         /// </summary>
-        [CanBeNull]
-        public BasicBlockGraph Body { get; set; }
+        public BasicBlockGraph? Body { get; set; }
 
         /// <summary>
         /// Gets the list of local values for this method.
         /// This list may be modified using <see cref="AddLocal"/>.
         /// </summary>
-        [NotNull, ItemNotNull]
         public IReadOnlyList<LocalValue> Values => _values;
 
         /// <summary>
         /// Gets the list of method calls for this method.
         /// This list may be modified using <see cref="AddCallInfo"/>.
         /// </summary>
-        [NotNull, ItemNotNull]
         public IReadOnlyList<MethodCallInfo> CallInfos => _callInfos;
 
         private readonly List<LocalValue> _values = new List<LocalValue>();
         private readonly List<MethodCallInfo> _callInfos = new List<MethodCallInfo>();
 
-        public CompiledMethod([NotNull] string fullName)
+        public CompiledMethod(string fullName)
         {
             FullName = fullName;
         }
@@ -49,7 +44,7 @@ namespace Cle.SemanticAnalysis.IR
         /// <summary>
         /// Creates a new local value of the specified type and returns its value index.
         /// </summary>
-        public ushort AddLocal([NotNull] TypeDefinition type, LocalFlags flags)
+        public ushort AddLocal(TypeDefinition type, LocalFlags flags)
         {
             if (_values.Count == ushort.MaxValue)
             {
@@ -66,7 +61,7 @@ namespace Cle.SemanticAnalysis.IR
         /// <param name="calleeIndex">The body index of the called method.</param>
         /// <param name="parameterLocals">Local indices for the parameters.</param>
         /// <param name="calleeName">The full name of the called method, used for debugging.</param>
-        public uint AddCallInfo(int calleeIndex, [NotNull] int[] parameterLocals, [NotNull] string calleeName)
+        public uint AddCallInfo(int calleeIndex, int[] parameterLocals, string calleeName)
         {
             _callInfos.Add(new MethodCallInfo(calleeIndex, parameterLocals, calleeName));
             return (uint)(_callInfos.Count - 1);

--- a/src/Cle.SemanticAnalysis/IR/MethodCallInfo.cs
+++ b/src/Cle.SemanticAnalysis/IR/MethodCallInfo.cs
@@ -1,6 +1,4 @@
-﻿using JetBrains.Annotations;
-
-namespace Cle.SemanticAnalysis.IR
+﻿namespace Cle.SemanticAnalysis.IR
 {
     /// <summary>
     /// Descriptor for a method call.
@@ -16,17 +14,15 @@ namespace Cle.SemanticAnalysis.IR
         /// <summary>
         /// Gets the local indices that are passed as parameters.
         /// </summary>
-        [NotNull]
         public int[] ParameterIndices { get; }
 
         /// <summary>
         /// Gets the full name of the called method.
         /// This information is only for debugging purposes.
         /// </summary>
-        [NotNull]
         public string CalleeFullName { get; }
 
-        public MethodCallInfo(int calleeIndex, [NotNull] int[] parameterIndices, [NotNull] string calleeFullName)
+        public MethodCallInfo(int calleeIndex, int[] parameterIndices, string calleeFullName)
         {
             CalleeIndex = calleeIndex;
             ParameterIndices = parameterIndices;

--- a/src/Cle.SemanticAnalysis/IR/Phi.cs
+++ b/src/Cle.SemanticAnalysis/IR/Phi.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Immutable;
-using JetBrains.Annotations;
 
 namespace Cle.SemanticAnalysis.IR
 {
@@ -16,10 +15,9 @@ namespace Cle.SemanticAnalysis.IR
         /// <summary>
         /// Gets the operand local indices.
         /// </summary>
-        [NotNull]
         public ImmutableList<int> Operands { get; }
 
-        public Phi(int destination, [NotNull] ImmutableList<int> operands)
+        public Phi(int destination, ImmutableList<int> operands)
         {
             Destination = destination;
             Operands = operands;

--- a/src/Cle.SemanticAnalysis/MethodCompiler.cs
+++ b/src/Cle.SemanticAnalysis/MethodCompiler.cs
@@ -2,11 +2,11 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Cle.Common;
 using Cle.Common.TypeSystem;
 using Cle.Parser.SyntaxTree;
 using Cle.SemanticAnalysis.IR;
-using JetBrains.Annotations;
 
 namespace Cle.SemanticAnalysis
 {
@@ -18,18 +18,18 @@ namespace Cle.SemanticAnalysis
     public class MethodCompiler : INameResolver
     {
         // These fields never change during the lifetime of the instance
-        [NotNull] private readonly IDiagnosticSink _diagnostics;
-        [NotNull] private readonly IDeclarationProvider _declarationProvider;
+        private readonly IDiagnosticSink _diagnostics;
+        private readonly IDeclarationProvider _declarationProvider;
 
         // These fields hold information for the current method and are reset by CompileBody()
-        [CanBeNull] private FunctionSyntax _syntaxTree;
-        [CanBeNull] private MethodDeclaration _declaration;
-        [CanBeNull] private string _definingNamespace;
-        [CanBeNull] private string _sourceFilename;
-        [NotNull] private readonly ScopedVariableMap _variableMap;
+        private FunctionSyntax? _syntaxTree;
+        private MethodDeclaration? _declaration;
+        private string? _definingNamespace;
+        private string? _sourceFilename;
+        private readonly ScopedVariableMap _variableMap;
 
         // These fields are reset by InternalCompile()
-        [CanBeNull] private CompiledMethod _methodInProgress;
+        private CompiledMethod? _methodInProgress;
 
         /// <summary>
         /// Verifies and creates type information for the method.
@@ -42,14 +42,13 @@ namespace Cle.SemanticAnalysis
         /// <param name="methodBodyIndex">The index associated with the compiled method body.</param>
         /// <param name="declarationProvider">The type provider to use for resolving custom types.</param>
         /// <param name="diagnosticSink">The receiver for any semantic errors or warnings.</param>
-        [CanBeNull]
-        public static MethodDeclaration CompileDeclaration(
-            [NotNull] FunctionSyntax syntax,
-            [NotNull] string definingNamespace,
-            [NotNull] string definingFilename,
+        public static MethodDeclaration? CompileDeclaration(
+            FunctionSyntax syntax,
+            string definingNamespace,
+            string definingFilename,
             int methodBodyIndex,
-            [NotNull] IDeclarationProvider declarationProvider,
-            [NotNull] IDiagnosticSink diagnosticSink)
+            IDeclarationProvider declarationProvider,
+            IDiagnosticSink diagnosticSink)
         {
             // Resolve the return type
             if (!TryResolveType(syntax.ReturnTypeName, diagnosticSink, syntax.Position, out var returnType))
@@ -109,8 +108,8 @@ namespace Cle.SemanticAnalysis
         /// <param name="declarationProvider">The provider for method and type declarations.</param>
         /// <param name="diagnosticSink">The receiver for any semantic errors or warnings.</param>
         public MethodCompiler(
-            [NotNull] IDeclarationProvider declarationProvider,
-            [NotNull] IDiagnosticSink diagnosticSink)
+            IDeclarationProvider declarationProvider,
+            IDiagnosticSink diagnosticSink)
         {
             _declarationProvider = declarationProvider;
             _diagnostics = diagnosticSink;
@@ -125,12 +124,11 @@ namespace Cle.SemanticAnalysis
         /// <param name="declaration">The method declaration.</param>
         /// <param name="definingNamespace">The namespace where the method is defined.</param>
         /// <param name="sourceFilename">The name of the file where the method is defined.</param>
-        [CanBeNull]
-        public CompiledMethod CompileBody(
-            [NotNull] FunctionSyntax syntaxTree,
-            [NotNull] MethodDeclaration declaration,
-            [NotNull] string definingNamespace,
-            [NotNull] string sourceFilename)
+        public CompiledMethod? CompileBody(
+            FunctionSyntax syntaxTree,
+            MethodDeclaration declaration,
+            string definingNamespace,
+            string sourceFilename)
         {
             // Reset most per-method fields
             _syntaxTree = syntaxTree;
@@ -142,8 +140,7 @@ namespace Cle.SemanticAnalysis
             return InternalCompile();
         }
 
-        [CanBeNull]
-        private CompiledMethod InternalCompile()
+        private CompiledMethod? InternalCompile()
         {
             Debug.Assert(_syntaxTree != null);
             Debug.Assert(_sourceFilename != null);
@@ -198,8 +195,8 @@ namespace Cle.SemanticAnalysis
             return _methodInProgress;
         }
 
-        private bool TryCompileBlock([NotNull] BlockSyntax block, [NotNull] BasicBlockBuilder builder,
-            [NotNull] out BasicBlockBuilder newBuilder, out bool returnGuaranteed)
+        private bool TryCompileBlock(BlockSyntax block, BasicBlockBuilder builder,
+            out BasicBlockBuilder newBuilder, out bool returnGuaranteed)
         {
             // Some statements may create new basic blocks, but the default is that they do not
             newBuilder = builder;
@@ -271,7 +268,7 @@ namespace Cle.SemanticAnalysis
             return true;
         }
 
-        private bool TryCompileAssignment([NotNull] AssignmentSyntax assignment, [NotNull] BasicBlockBuilder builder)
+        private bool TryCompileAssignment(AssignmentSyntax assignment, BasicBlockBuilder builder)
         {
             Debug.Assert(_methodInProgress != null);
 
@@ -295,8 +292,8 @@ namespace Cle.SemanticAnalysis
             return true;
         }
 
-        private bool TryCompileIf([NotNull] IfStatementSyntax ifSyntax, [NotNull] BasicBlockBuilder builder,
-            [NotNull] out BasicBlockBuilder newBuilder, out bool returnGuaranteed)
+        private bool TryCompileIf(IfStatementSyntax ifSyntax, BasicBlockBuilder builder,
+            out BasicBlockBuilder newBuilder, out bool returnGuaranteed)
         {
             newBuilder = builder; // Default failure case
             returnGuaranteed = false;
@@ -378,8 +375,8 @@ namespace Cle.SemanticAnalysis
             }
         }
 
-        private bool TryCompileWhile([NotNull] WhileStatementSyntax whileSyntax, [NotNull] BasicBlockBuilder builder,
-            [NotNull] out BasicBlockBuilder newBuilder)
+        private bool TryCompileWhile(WhileStatementSyntax whileSyntax, BasicBlockBuilder builder,
+            out BasicBlockBuilder newBuilder)
         {
             newBuilder = builder; // Default failure case
             Debug.Assert(_methodInProgress != null);
@@ -414,7 +411,7 @@ namespace Cle.SemanticAnalysis
             return true;
         }
 
-        private bool TryCompileReturn([NotNull] ReturnStatementSyntax syntax, [NotNull] BasicBlockBuilder builder)
+        private bool TryCompileReturn(ReturnStatementSyntax syntax, BasicBlockBuilder builder)
         {
             Debug.Assert(_methodInProgress != null);
             Debug.Assert(_declaration != null);
@@ -448,8 +445,8 @@ namespace Cle.SemanticAnalysis
             return true;
         }
 
-        private bool TryCompileVariableDeclaration([NotNull] VariableDeclarationSyntax declaration,
-            [NotNull] BasicBlockBuilder builder)
+        private bool TryCompileVariableDeclaration(VariableDeclarationSyntax declaration,
+            BasicBlockBuilder builder)
         {
             Debug.Assert(_methodInProgress != null);
             var localCount = _methodInProgress.Values.Count;
@@ -497,10 +494,10 @@ namespace Cle.SemanticAnalysis
         }
         
         private static bool TryResolveType(
-            [NotNull] string typeName, 
-            [NotNull] IDiagnosticSink diagnostics,
+            string typeName, 
+            IDiagnosticSink diagnostics,
             TextPosition position,
-            [CanBeNull] out TypeDefinition type)
+            [NotNullWhenTrue] out TypeDefinition? type)
         {
             // TODO: Proper type resolution with the declaration provider
             switch (typeName)

--- a/src/Cle.SemanticAnalysis/MethodDeclaration.cs
+++ b/src/Cle.SemanticAnalysis/MethodDeclaration.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Immutable;
 using Cle.Common;
 using Cle.Common.TypeSystem;
-using JetBrains.Annotations;
 
 namespace Cle.SemanticAnalysis
 {
@@ -23,13 +22,11 @@ namespace Cle.SemanticAnalysis
         /// <summary>
         /// Gets the return type of this method.
         /// </summary>
-        [NotNull]
         public TypeDefinition ReturnType { get; }
 
         /// <summary>
         /// Gets the types of the parameters to this method.
         /// </summary>
-        [NotNull]
         public ImmutableList<TypeDefinition> ParameterTypes { get; }
 
         /// <summary>
@@ -41,14 +38,12 @@ namespace Cle.SemanticAnalysis
         /// Gets the full name of this method.
         /// This is only used for debugging purposes.
         /// </summary>
-        [NotNull]
         public string FullName { get; }
 
         /// <summary>
         /// Gets the name of the file this method is defined in.
         /// This is used for visibility resolution of private methods.
         /// </summary>
-        [NotNull]
         public string DefiningFilename { get; }
 
         /// <summary>
@@ -58,11 +53,11 @@ namespace Cle.SemanticAnalysis
 
         public MethodDeclaration(
             int bodyIndex,
-            [NotNull] TypeDefinition returnType, 
-            [NotNull, ItemNotNull] ImmutableList<TypeDefinition> parameterTypes,
+            TypeDefinition returnType, 
+            ImmutableList<TypeDefinition> parameterTypes,
             Visibility visibility,
-            [NotNull] string fullName,
-            [NotNull] string definingFilename,
+            string fullName,
+            string definingFilename,
             TextPosition sourcePosition,
             bool isEntryPoint)
         {

--- a/src/Cle.SemanticAnalysis/MethodDisassembler.cs
+++ b/src/Cle.SemanticAnalysis/MethodDisassembler.cs
@@ -1,7 +1,6 @@
 ﻿using System.Text;
 using Cle.Common.TypeSystem;
 using Cle.SemanticAnalysis.IR;
-using JetBrains.Annotations;
 
 namespace Cle.SemanticAnalysis
 {
@@ -15,7 +14,7 @@ namespace Cle.SemanticAnalysis
         /// <summary>
         /// Writes the type information and disassembled basic blocks of the method to the output string builder.
         /// </summary>
-        public static void Disassemble([NotNull] CompiledMethod method, [NotNull] StringBuilder outputBuilder)
+        public static void Disassemble(CompiledMethod method, StringBuilder outputBuilder)
         {
             // Write the types and initial values of locals
             for (var i = 0; i < method.Values.Count; i++)
@@ -32,8 +31,11 @@ namespace Cle.SemanticAnalysis
         /// <summary>
         /// Writes the disassembled basic blocks of the method to the output string builder.
         /// </summary>
-        public static void DisassembleBody([NotNull] CompiledMethod method, [NotNull] StringBuilder outputBuilder)
+        public static void DisassembleBody(CompiledMethod method, StringBuilder outputBuilder)
         {
+            if (method.Body is null)
+                return;
+
             for (var blockIndex = 0; blockIndex < method.Body.BasicBlocks.Count; blockIndex++)
             {
                 // The block may be null as the builder omits dead blocks but preserves numbering

--- a/src/Cle.SemanticAnalysis/ScopedVariableMap.cs
+++ b/src/Cle.SemanticAnalysis/ScopedVariableMap.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using JetBrains.Annotations;
 
 namespace Cle.SemanticAnalysis
 {
@@ -62,7 +61,7 @@ namespace Cle.SemanticAnalysis
         /// Returns false if the name already exists in any scope.
         /// Throws if there is no scope on the stack.
         /// </summary>
-        public bool TryAddVariable([NotNull] string name, int localIndex)
+        public bool TryAddVariable(string name, int localIndex)
         {
             if (_scopeStack.Count == 0)
                 throw new InvalidOperationException("Scope stack is empty");
@@ -83,7 +82,7 @@ namespace Cle.SemanticAnalysis
         /// Returns false if the variable does not exist in any scope.
         /// Throws if there is no scope on the stack.
         /// </summary>
-        public bool TryGetVariable([NotNull] string name, out int localIndex)
+        public bool TryGetVariable(string name, out int localIndex)
         {
             if (_scopeStack.Count == 0)
                 throw new InvalidOperationException("Scope stack is empty");

--- a/src/Cle.SemanticAnalysis/SsaConverter.cs
+++ b/src/Cle.SemanticAnalysis/SsaConverter.cs
@@ -4,7 +4,6 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using Cle.Common.TypeSystem;
 using Cle.SemanticAnalysis.IR;
-using JetBrains.Annotations;
 
 namespace Cle.SemanticAnalysis
 {
@@ -29,6 +28,8 @@ namespace Cle.SemanticAnalysis
     /// </remarks>
     public class SsaConverter
     {
+        // These are all set by ConvertToSsa
+#nullable disable
         private CompiledMethod _originalMethod;
         private CompiledMethod _newMethod;
         private BasicBlockGraphBuilder _blockGraphBuilder;
@@ -40,14 +41,14 @@ namespace Cle.SemanticAnalysis
         private bool[] _isSealed;
         private int[] _predecessorsSet;
         private List<(ushort variable, ushort phiValue)>[] _incompletePhis;
+#nullable restore
 
         /// <summary>
         /// Returns a new <see cref="CompiledMethod"/> instance equivalent to the original
         /// <paramref name="method"/> after SSA conversion.
         /// </summary>
         /// <param name="method">The non-SSA method to convert.</param>
-        [NotNull]
-        public CompiledMethod ConvertToSsa([NotNull] CompiledMethod method)
+        public CompiledMethod ConvertToSsa(CompiledMethod method)
         {
             if (method.Body is null)
                 throw new ArgumentNullException(nameof(method), "Method must have body");
@@ -101,7 +102,7 @@ namespace Cle.SemanticAnalysis
         /// </summary>
         /// <param name="blockIndex">The basic block index.</param>
         /// <param name="builder">The builder for the basic block.</param>
-        private void ConvertBlock(int blockIndex, [NotNull] BasicBlockBuilder builder)
+        private void ConvertBlock(int blockIndex, BasicBlockBuilder builder)
         {
             Debug.Assert(_originalMethod.Body != null);
             var block = _originalMethod.Body.BasicBlocks[blockIndex];

--- a/test/Cle.Benchmarks/BenchmarkDiagnosticsSink.cs
+++ b/test/Cle.Benchmarks/BenchmarkDiagnosticsSink.cs
@@ -11,12 +11,12 @@ namespace Cle.Benchmarks
             DiagnosticCount++;
         }
 
-        public void Add(DiagnosticCode code, TextPosition position, string actual)
+        public void Add(DiagnosticCode code, TextPosition position, string? actual)
         {
             DiagnosticCount++;
         }
 
-        public void Add(DiagnosticCode code, TextPosition position, string actual, string expected)
+        public void Add(DiagnosticCode code, TextPosition position, string? actual, string? expected)
         {
             DiagnosticCount++;
         }

--- a/test/Cle.Benchmarks/Cle.Benchmarks.csproj
+++ b/test/Cle.Benchmarks/Cle.Benchmarks.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <LangVersion>8.0</LangVersion>
+    <NullableContextOptions>enable</NullableContextOptions>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Cle.Benchmarks/Cle.Benchmarks.csproj
+++ b/test/Cle.Benchmarks/Cle.Benchmarks.csproj
@@ -1,9 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Cle.Benchmarks/Compiler/NullOutputProvider.cs
+++ b/test/Cle.Benchmarks/Compiler/NullOutputProvider.cs
@@ -5,17 +5,17 @@ namespace Cle.Benchmarks.Compiler
 {
     internal class NullOutputProvider : IOutputFileProvider
     {
-        public Stream GetExecutableStream()
+        public Stream? GetExecutableStream()
         {
             return new EmptyStream();
         }
 
-        public TextWriter GetDisassemblyWriter()
+        public TextWriter? GetDisassemblyWriter()
         {
             return null;
         }
 
-        public TextWriter GetDebugFileWriter()
+        public TextWriter? GetDebugFileWriter()
         {
             return null;
         }

--- a/test/Cle.Benchmarks/Compiler/SingleFileProvider.cs
+++ b/test/Cle.Benchmarks/Compiler/SingleFileProvider.cs
@@ -15,7 +15,7 @@ namespace Cle.Benchmarks.Compiler
             _source = Encoding.UTF8.GetBytes(source).AsMemory();
         }
 
-        public bool TryGetFilenamesForModule(string moduleName, out IEnumerable<string> filenames)
+        public bool TryGetFilenamesForModule(string moduleName, out IEnumerable<string>? filenames)
         {
             filenames = s_filenames;
             return true;

--- a/test/Cle.Benchmarks/SemanticAnalysis/SsaConverterBenchmarks.cs
+++ b/test/Cle.Benchmarks/SemanticAnalysis/SsaConverterBenchmarks.cs
@@ -107,13 +107,13 @@ private int32 CollatzOnCollatz(int32 n)
 
             // Compile the method body
             var result = new MethodCompiler(declarationProvider, diagnostics)
-                .CompileBody(syntaxTree.Functions[0], declaration, syntaxTree.Namespace, sourceFilename);
+                .CompileBody(syntaxTree.Functions[0], declaration!, syntaxTree.Namespace, sourceFilename);
             
             if (diagnostics.DiagnosticCount > 0)
             {
                 throw new InvalidOperationException("Expected no diagnostics");
             }
-            return result;
+            return result!;
         }
     }
 

--- a/test/Cle.CodeGeneration.UnitTests/Cle.CodeGeneration.UnitTests.csproj
+++ b/test/Cle.CodeGeneration.UnitTests/Cle.CodeGeneration.UnitTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Cle.CodeGeneration.UnitTests/Cle.CodeGeneration.UnitTests.csproj
+++ b/test/Cle.CodeGeneration.UnitTests/Cle.CodeGeneration.UnitTests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <LangVersion>8.0</LangVersion>
+    <NullableContextOptions>enable</NullableContextOptions>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Cle.Compiler.UnitTests/Cle.Compiler.UnitTests.csproj
+++ b/test/Cle.Compiler.UnitTests/Cle.Compiler.UnitTests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <LangVersion>8.0</LangVersion>
+    <NullableContextOptions>enable</NullableContextOptions>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Cle.Compiler.UnitTests/Cle.Compiler.UnitTests.csproj
+++ b/test/Cle.Compiler.UnitTests/Cle.Compiler.UnitTests.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Cle.Compiler.UnitTests/CompilationTests.cs
+++ b/test/Cle.Compiler.UnitTests/CompilationTests.cs
@@ -4,7 +4,6 @@ using Cle.Common;
 using Cle.Parser.SyntaxTree;
 using Cle.SemanticAnalysis;
 using Cle.SemanticAnalysis.IR;
-using JetBrains.Annotations;
 using NUnit.Framework;
 
 namespace Cle.Compiler.UnitTests
@@ -267,10 +266,10 @@ namespace Cle.Compiler.UnitTests
         }
 
         private static MethodDeclaration CreateDeclaration(
-            [NotNull] string methodName,
+            string methodName,
             Visibility visibility,
-            [NotNull] string filename,
-            [NotNull] Compilation compilation)
+            string filename,
+            Compilation compilation)
         {
             var diagnostics = new SingleFileDiagnosticSink();
             diagnostics.Reset(".", filename);
@@ -284,7 +283,7 @@ namespace Cle.Compiler.UnitTests
             Assert.That(declaration, Is.Not.Null);
             Assert.That(diagnostics.Diagnostics, Is.Empty);
 
-            return declaration;
+            return declaration!;
         }
     }
 }

--- a/test/Cle.Compiler.UnitTests/CompilerDriverTests.cs
+++ b/test/Cle.Compiler.UnitTests/CompilerDriverTests.cs
@@ -215,12 +215,12 @@ private int32 Main() { return 0; }";
                 Assert.That(result.Diagnostics, Has.Exactly(0).Items);
 
                 Assert.That(outputProvider.ExecutableStream, Is.Not.Null);
-                Assert.That(outputProvider.ExecutableStream.Position, Is.GreaterThan(0));
+                Assert.That(outputProvider.ExecutableStream!.Position, Is.GreaterThan(0));
 
                 if (emitDisassembly)
                 {
                     Assert.That(outputProvider.DisassemblyWriter, Is.Not.Null);
-                    Assert.That(outputProvider.DisassemblyWriter.ToString(), Does.Contain("Test::Main"));
+                    Assert.That(outputProvider.DisassemblyWriter!.ToString(), Does.Contain("Test::Main"));
                 }
                 else
                 {
@@ -343,7 +343,8 @@ public int32 ComplexMethod() { return 42; }";
                     sourceProvider, outputProvider);
 
                 var writer = outputProvider.DebugWriter;
-                Assert.That(writer.ToString(), Does.Contain("; Test::SimpleMethod"));
+                Assert.That(writer, Is.Not.Null);
+                Assert.That(writer!.ToString(), Does.Contain("; Test::SimpleMethod"));
                 Assert.That(writer.ToString(), Does.Contain("  Return #0"));
                 Assert.That(writer.ToString(), Does.Not.Contain("ComplexMethod"));
             }

--- a/test/Cle.Compiler.UnitTests/TestingOutputFileProvider.cs
+++ b/test/Cle.Compiler.UnitTests/TestingOutputFileProvider.cs
@@ -9,7 +9,7 @@ namespace Cle.Compiler.UnitTests
         /// Gets the mock output stream.
         /// Null if never requested via <see cref="GetExecutableStream"/>.
         /// </summary>
-        public MemoryStream ExecutableStream { get; private set; }
+        public MemoryStream? ExecutableStream { get; private set; }
 
         /// <summary>
         /// If true, <see cref="GetExecutableStream"/> will always return <c>null</c>.
@@ -25,13 +25,13 @@ namespace Cle.Compiler.UnitTests
         /// Gets the mock disassembly writer.
         /// Null if never requested via <see cref="GetDisassemblyWriter"/>.
         /// </summary>
-        public StringWriter DisassemblyWriter { get; private set; }
+        public StringWriter? DisassemblyWriter { get; private set; }
 
         /// <summary>
         /// Gets the mock debug log writer.
         /// Null if never requested via <see cref="GetDebugFileWriter"/>.
         /// </summary>
-        public StringWriter DebugWriter { get; private set; }
+        public StringWriter? DebugWriter { get; private set; }
 
         public void Dispose()
         {
@@ -40,7 +40,7 @@ namespace Cle.Compiler.UnitTests
             DebugWriter?.Dispose();
         }
 
-        public Stream GetExecutableStream()
+        public Stream? GetExecutableStream()
         {
             if (FailExecutable)
                 return null;
@@ -48,7 +48,7 @@ namespace Cle.Compiler.UnitTests
             return ExecutableStream ?? (ExecutableStream = new MemoryStream());
         }
 
-        public TextWriter GetDisassemblyWriter()
+        public TextWriter? GetDisassemblyWriter()
         {
             if (FailDisassembly)
                 return null;
@@ -56,7 +56,7 @@ namespace Cle.Compiler.UnitTests
             return DisassemblyWriter ?? (DisassemblyWriter = new StringWriter());
         }
 
-        public TextWriter GetDebugFileWriter()
+        public TextWriter? GetDebugFileWriter()
         {
             return DebugWriter ?? (DebugWriter = new StringWriter());
         }

--- a/test/Cle.Compiler.UnitTests/TestingSourceFileProvider.cs
+++ b/test/Cle.Compiler.UnitTests/TestingSourceFileProvider.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using JetBrains.Annotations;
 using NUnit.Framework;
 
 namespace Cle.Compiler.UnitTests
@@ -24,7 +23,7 @@ namespace Cle.Compiler.UnitTests
         /// File contents as an UTF-16 string. The contents will be converted to UTF-8.
         /// Specify null to create a missing file.
         /// </param>
-        public void Add([NotNull] string moduleName, [NotNull] string filename, [CanBeNull] string source)
+        public void Add(string moduleName, string filename, string? source)
         {
             if (!_moduleFiles.ContainsKey(moduleName))
             {
@@ -38,7 +37,7 @@ namespace Cle.Compiler.UnitTests
             }
         }
 
-        public bool TryGetFilenamesForModule(string moduleName, out IEnumerable<string> filenames)
+        public bool TryGetFilenamesForModule(string moduleName, out IEnumerable<string>? filenames)
         {
             if (_moduleFiles.TryGetValue(moduleName, out var names))
             {
@@ -71,7 +70,7 @@ namespace Cle.Compiler.UnitTests
         /// <summary>
         /// Asserts that the given file has been accessed.
         /// </summary>
-        public void AssertFileWasRead([NotNull] string filename)
+        public void AssertFileWasRead(string filename)
         {
             Assert.That(_readFiles.Contains(filename), Is.True, $"File {filename} was not accessed");
         }

--- a/test/Cle.Frontend.UnitTests/Cle.Frontend.UnitTests.csproj
+++ b/test/Cle.Frontend.UnitTests/Cle.Frontend.UnitTests.csproj
@@ -3,11 +3,11 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <LangVersion>8.0</LangVersion>
+    <NullableContextOptions>enable</NullableContextOptions>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2018.2.1" />
     <PackageReference Include="nunit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />

--- a/test/Cle.Frontend.UnitTests/Cle.Frontend.UnitTests.csproj
+++ b/test/Cle.Frontend.UnitTests/Cle.Frontend.UnitTests.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Cle.Frontend.UnitTests/CommandLineParserTests.cs
+++ b/test/Cle.Frontend.UnitTests/CommandLineParserTests.cs
@@ -34,7 +34,7 @@ namespace Cle.Frontend.UnitTests
                 Is.True);
             Assert.That(options, Is.Not.Null);
 
-            Assert.That(options.EmitDisassembly, Is.False);
+            Assert.That(options!.EmitDisassembly, Is.False);
             Assert.That(options.DebugOutput, Is.False);
             Assert.That(options.MainModule, Is.EqualTo("."));
         }
@@ -48,7 +48,7 @@ namespace Cle.Frontend.UnitTests
             Assert.That(CommandLineParser.TryParseArguments(new[] { "--dump", "\\d+" }, output, out var options),
                 Is.True);
             Assert.That(options, Is.Not.Null);
-            Assert.That(options.DebugPattern, Is.EqualTo("\\d+"));
+            Assert.That(options!.DebugPattern, Is.EqualTo("\\d+"));
             Assert.That(options.DebugOutput, Is.True);
         }
 
@@ -60,7 +60,7 @@ namespace Cle.Frontend.UnitTests
             Assert.That(CommandLineParser.TryParseArguments(new[] { "--disasm" }, output, out var options),
                 Is.True);
             Assert.That(options, Is.Not.Null);
-            Assert.That(options.EmitDisassembly, Is.True);
+            Assert.That(options!.EmitDisassembly, Is.True);
         }
 
         [Test]
@@ -71,7 +71,7 @@ namespace Cle.Frontend.UnitTests
             Assert.That(CommandLineParser.TryParseArguments(new[] { "MainModule" }, output, out var options),
                 Is.True);
             Assert.That(options, Is.Not.Null);
-            Assert.That(options.MainModule, Is.EqualTo("MainModule"));
+            Assert.That(options!.MainModule, Is.EqualTo("MainModule"));
         }
 
         [Test]

--- a/test/Cle.IntegrationTests/Cle.IntegrationTests.csproj
+++ b/test/Cle.IntegrationTests/Cle.IntegrationTests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <LangVersion>8.0</LangVersion>
+    <NullableContextOptions>enable</NullableContextOptions>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Cle.IntegrationTests/Cle.IntegrationTests.csproj
+++ b/test/Cle.IntegrationTests/Cle.IntegrationTests.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Cle.Parser.UnitTests/Cle.Parser.UnitTests.csproj
+++ b/test/Cle.Parser.UnitTests/Cle.Parser.UnitTests.csproj
@@ -3,11 +3,11 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <LangVersion>8.0</LangVersion>
+    <NullableContextOptions>enable</NullableContextOptions>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2018.2.1" />
     <PackageReference Include="nunit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />

--- a/test/Cle.Parser.UnitTests/Cle.Parser.UnitTests.csproj
+++ b/test/Cle.Parser.UnitTests/Cle.Parser.UnitTests.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Cle.Parser.UnitTests/LexerTests.cs
+++ b/test/Cle.Parser.UnitTests/LexerTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Text;
 using Cle.Common;
-using JetBrains.Annotations;
 using NUnit.Framework;
 
 namespace Cle.Parser.UnitTests
@@ -254,7 +253,7 @@ namespace//Look ma, no spaces!
         /// <summary>
         /// Converts a UTF-16 encoded source code string into a view of a UTF-8 array.
         /// </summary>
-        private static Memory<byte> StringToMemory([NotNull] string source)
+        private static Memory<byte> StringToMemory(string source)
         {
             return Encoding.UTF8.GetBytes(source).AsMemory();
         }
@@ -262,7 +261,6 @@ namespace//Look ma, no spaces!
         /// <summary>
         /// Converts a UTF-8 encoded span into a UTF-16 string.
         /// </summary>
-        [NotNull]
         private static string Utf8ToString(ReadOnlySpan<byte> span)
         {
             return Encoding.UTF8.GetString(span);

--- a/test/Cle.Parser.UnitTests/SyntaxParserTests/ExpressionTests.cs
+++ b/test/Cle.Parser.UnitTests/SyntaxParserTests/ExpressionTests.cs
@@ -1,6 +1,5 @@
 using Cle.Common;
 using Cle.Parser.SyntaxTree;
-using JetBrains.Annotations;
 using NUnit.Framework;
 
 namespace Cle.Parser.UnitTests.SyntaxParserTests
@@ -21,7 +20,7 @@ namespace Cle.Parser.UnitTests.SyntaxParserTests
             Assert.That(returnValue, Is.True);
             Assert.That(expression, Is.Not.Null);
             Assert.That(expression, Is.InstanceOf<IntegerLiteralSyntax>());
-            Assert.That(((IntegerLiteralSyntax)expression).Value, Is.EqualTo(expected));
+            Assert.That(((IntegerLiteralSyntax)expression!).Value, Is.EqualTo(expected));
         }
 
         [TestCase("0xDEAD")]
@@ -50,7 +49,7 @@ namespace Cle.Parser.UnitTests.SyntaxParserTests
             Assert.That(returnValue, Is.True);
             Assert.That(expression, Is.Not.Null);
             Assert.That(expression, Is.InstanceOf<BooleanLiteralSyntax>());
-            Assert.That(((BooleanLiteralSyntax)expression).Value, Is.EqualTo(expected));
+            Assert.That(((BooleanLiteralSyntax)expression!).Value, Is.EqualTo(expected));
         }
 
         [TestCase("i")]
@@ -65,7 +64,7 @@ namespace Cle.Parser.UnitTests.SyntaxParserTests
             Assert.That(returnValue, Is.True);
             Assert.That(expression, Is.Not.Null);
 
-            var reference = (NamedValueSyntax)expression;
+            var reference = (NamedValueSyntax)expression!;
             Assert.That(reference.Name, Is.EqualTo(name));
         }
 
@@ -95,7 +94,7 @@ namespace Cle.Parser.UnitTests.SyntaxParserTests
             Assert.That(returnValue, Is.True);
             Assert.That(expression, Is.Not.Null);
 
-            var unary = (UnaryExpressionSyntax)expression;
+            var unary = (UnaryExpressionSyntax)expression!;
             Assert.That(unary.Operation, Is.EqualTo(expectedOp));
             Assert.That(unary.InnerExpression, Is.InstanceOf<IntegerLiteralSyntax>());
             Assert.That(((IntegerLiteralSyntax)unary.InnerExpression).Value, Is.EqualTo(123));
@@ -112,7 +111,7 @@ namespace Cle.Parser.UnitTests.SyntaxParserTests
             Assert.That(returnValue, Is.True);
             Assert.That(expression, Is.Not.Null);
 
-            var unary = (UnaryExpressionSyntax)expression;
+            var unary = (UnaryExpressionSyntax)expression!;
             Assert.That(unary.Operation, Is.EqualTo(expectedOp));
             Assert.That(unary.InnerExpression, Is.InstanceOf<BooleanLiteralSyntax>());
             Assert.That(((BooleanLiteralSyntax)unary.InnerExpression).Value, Is.EqualTo(true));
@@ -129,7 +128,7 @@ namespace Cle.Parser.UnitTests.SyntaxParserTests
             Assert.That(returnValue, Is.True);
             Assert.That(expression, Is.Not.Null);
 
-            var unary = (UnaryExpressionSyntax)expression;
+            var unary = (UnaryExpressionSyntax)expression!;
             Assert.That(unary.Operation, Is.EqualTo(UnaryOperation.Minus));
 
             var innerUnary = (UnaryExpressionSyntax)unary.InnerExpression;
@@ -151,7 +150,7 @@ namespace Cle.Parser.UnitTests.SyntaxParserTests
         [TestCase("1 == 2 == 3", BinaryOperation.Equal)]
         [TestCase("(1 + 2 + 3)", BinaryOperation.Plus)] // Parens outside the expression have no effect
         [TestCase("(1 ^ 2 ^ 3)", BinaryOperation.Xor)]
-        public void Binary_operation_is_left_associative([NotNull] string source, BinaryOperation operation)
+        public void Binary_operation_is_left_associative(string source, BinaryOperation operation)
         {
             var parser = GetParserInstance(source, out var diagnostics);
 
@@ -161,7 +160,7 @@ namespace Cle.Parser.UnitTests.SyntaxParserTests
             Assert.That(returnValue, Is.True);
             Assert.That(expression, Is.Not.Null);
 
-            var binary = (BinaryExpressionSyntax)expression;
+            var binary = (BinaryExpressionSyntax)expression!;
             Assert.That(binary.Operation, Is.EqualTo(operation));
 
             var left = (BinaryExpressionSyntax)binary.Left;
@@ -186,7 +185,7 @@ namespace Cle.Parser.UnitTests.SyntaxParserTests
             Assert.That(returnValue, Is.True);
             Assert.That(expression, Is.Not.Null);
 
-            var binary = (BinaryExpressionSyntax)expression;
+            var binary = (BinaryExpressionSyntax)expression!;
             Assert.That(binary.Operation, Is.EqualTo(BinaryOperation.Plus));
 
             var left = (BinaryExpressionSyntax)binary.Left;
@@ -211,7 +210,7 @@ namespace Cle.Parser.UnitTests.SyntaxParserTests
             Assert.That(returnValue, Is.True);
             Assert.That(expression, Is.Not.Null);
 
-            var binary = (BinaryExpressionSyntax)expression;
+            var binary = (BinaryExpressionSyntax)expression!;
             Assert.That(binary.Operation, Is.EqualTo(BinaryOperation.Plus));
 
             Assert.That(binary.Left, Is.InstanceOf<IntegerLiteralSyntax>());
@@ -236,7 +235,7 @@ namespace Cle.Parser.UnitTests.SyntaxParserTests
             Assert.That(returnValue, Is.True);
             Assert.That(expression, Is.Not.Null);
 
-            var binary = (BinaryExpressionSyntax)expression;
+            var binary = (BinaryExpressionSyntax)expression!;
             Assert.That(binary.Operation, Is.EqualTo(BinaryOperation.Minus));
 
             Assert.That(binary.Left, Is.InstanceOf<IntegerLiteralSyntax>());
@@ -261,7 +260,7 @@ namespace Cle.Parser.UnitTests.SyntaxParserTests
             Assert.That(returnValue, Is.True);
             Assert.That(expression, Is.Not.Null);
 
-            var binary = (BinaryExpressionSyntax)expression;
+            var binary = (BinaryExpressionSyntax)expression!;
             Assert.That(binary.Operation, Is.EqualTo(BinaryOperation.Minus));
 
             Assert.That(binary.Left, Is.InstanceOf<IntegerLiteralSyntax>());
@@ -284,7 +283,7 @@ namespace Cle.Parser.UnitTests.SyntaxParserTests
             Assert.That(returnValue, Is.True);
             Assert.That(expression, Is.Not.Null);
 
-            var binary = (BinaryExpressionSyntax)expression;
+            var binary = (BinaryExpressionSyntax)expression!;
             Assert.That(binary.Operation, Is.EqualTo(BinaryOperation.Plus));
 
             Assert.That(binary.Left, Is.InstanceOf<NamedValueSyntax>());
@@ -307,7 +306,7 @@ namespace Cle.Parser.UnitTests.SyntaxParserTests
             Assert.That(returnValue, Is.True);
             Assert.That(expression, Is.Not.Null);
 
-            var binary = (BinaryExpressionSyntax)expression;
+            var binary = (BinaryExpressionSyntax)expression!;
             Assert.That(binary.Operation, Is.EqualTo(BinaryOperation.Minus));
 
             Assert.That(binary.Left, Is.InstanceOf<IntegerLiteralSyntax>());
@@ -333,7 +332,7 @@ namespace Cle.Parser.UnitTests.SyntaxParserTests
             Assert.That(returnValue, Is.True);
             Assert.That(expression, Is.Not.Null);
 
-            var binary = (BinaryExpressionSyntax)expression;
+            var binary = (BinaryExpressionSyntax)expression!;
             Assert.That(binary.Operation, Is.EqualTo(BinaryOperation.Times));
 
             var left = (BinaryExpressionSyntax)binary.Left;
@@ -358,7 +357,7 @@ namespace Cle.Parser.UnitTests.SyntaxParserTests
             Assert.That(returnValue, Is.True);
             Assert.That(expression, Is.Not.Null);
 
-            var binary = (BinaryExpressionSyntax)expression;
+            var binary = (BinaryExpressionSyntax)expression!;
             Assert.That(binary.Operation, Is.EqualTo(BinaryOperation.Plus));
 
             Assert.That(binary.Left, Is.InstanceOf<IntegerLiteralSyntax>());
@@ -388,7 +387,7 @@ namespace Cle.Parser.UnitTests.SyntaxParserTests
             Assert.That(returnValue, Is.True);
             Assert.That(expression, Is.Not.Null);
 
-            var binary = (BinaryExpressionSyntax)expression;
+            var binary = (BinaryExpressionSyntax)expression!;
             Assert.That(binary.Operation, Is.EqualTo(expected));
 
             Assert.That(binary.Left, Is.InstanceOf<BinaryExpressionSyntax>());
@@ -409,7 +408,7 @@ namespace Cle.Parser.UnitTests.SyntaxParserTests
             Assert.That(returnValue, Is.True);
             Assert.That(expression, Is.Not.Null);
 
-            var binary = (BinaryExpressionSyntax)expression;
+            var binary = (BinaryExpressionSyntax)expression!;
             Assert.That(binary.Operation, Is.EqualTo(BinaryOperation.ShortCircuitAnd));
 
             Assert.That(binary.Left, Is.InstanceOf<BinaryExpressionSyntax>());
@@ -430,7 +429,7 @@ namespace Cle.Parser.UnitTests.SyntaxParserTests
             Assert.That(returnValue, Is.True);
             Assert.That(expression, Is.Not.Null);
 
-            var binary = (BinaryExpressionSyntax)expression;
+            var binary = (BinaryExpressionSyntax)expression!;
             Assert.That(binary.Operation, Is.EqualTo(BinaryOperation.ShiftLeft));
 
             Assert.That(binary.Left, Is.InstanceOf<BinaryExpressionSyntax>());
@@ -522,7 +521,7 @@ namespace Cle.Parser.UnitTests.SyntaxParserTests
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             Assert.That(expression, Is.Not.Null);
 
-            var call = (FunctionCallSyntax)expression;
+            var call = (FunctionCallSyntax)expression!;
             Assert.That(call.Function, Is.EqualTo("Namespace::Function"));
             Assert.That(call.Parameters, Is.Empty);
         }
@@ -536,7 +535,7 @@ namespace Cle.Parser.UnitTests.SyntaxParserTests
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             Assert.That(expression, Is.Not.Null);
 
-            var call = (FunctionCallSyntax)expression;
+            var call = (FunctionCallSyntax)expression!;
             Assert.That(call.Function, Is.EqualTo("Fun"));
             Assert.That(call.Parameters, Has.Exactly(2).Items);
             Assert.That(call.Parameters[0], Is.InstanceOf<IntegerLiteralSyntax>());

--- a/test/Cle.Parser.UnitTests/SyntaxParserTests/FunctionTests.cs
+++ b/test/Cle.Parser.UnitTests/SyntaxParserTests/FunctionTests.cs
@@ -135,7 +135,7 @@ internal int32 OneHundred()
             Assert.That(returnStatement.Position.ByteInLine, Is.EqualTo(4));
             Assert.That(returnStatement.ResultExpression, Is.Not.Null);
             Assert.That(returnStatement.ResultExpression, Is.InstanceOf<IntegerLiteralSyntax>());
-            Assert.That(((IntegerLiteralSyntax)returnStatement.ResultExpression).Value, Is.EqualTo(100));
+            Assert.That(((IntegerLiteralSyntax)returnStatement.ResultExpression!).Value, Is.EqualTo(100));
         }
 
         [Test]
@@ -159,7 +159,7 @@ internal int32 OneHundred()
             Assert.That(returnStatement.Position.ByteInLine, Is.EqualTo(4));
             Assert.That(returnStatement.ResultExpression, Is.Not.Null);
             Assert.That(returnStatement.ResultExpression, Is.InstanceOf<BinaryExpressionSyntax>());
-            Assert.That(((BinaryExpressionSyntax)returnStatement.ResultExpression).Operation,
+            Assert.That(((BinaryExpressionSyntax)returnStatement.ResultExpression!).Operation,
                 Is.EqualTo(BinaryOperation.Times));
         }
 

--- a/test/Cle.Parser.UnitTests/SyntaxParserTests/IfTests.cs
+++ b/test/Cle.Parser.UnitTests/SyntaxParserTests/IfTests.cs
@@ -26,7 +26,7 @@ private void Function()
             Assert.That(statement.ThenBlockSyntax.Statements, Is.Empty);
             Assert.That(statement.ElseSyntax, Is.Not.Null);
             Assert.That(statement.ElseSyntax, Is.InstanceOf<BlockSyntax>());
-            Assert.That(((BlockSyntax)statement.ElseSyntax).Statements, Is.Empty);
+            Assert.That(((BlockSyntax)statement.ElseSyntax!).Statements, Is.Empty);
         }
 
         [Test]
@@ -49,7 +49,7 @@ private void Function()
             Assert.That(statement.ThenBlockSyntax.Statements, Has.Exactly(1).Items);
             Assert.That(statement.ElseSyntax, Is.Not.Null);
             Assert.That(statement.ElseSyntax, Is.InstanceOf<BlockSyntax>());
-            Assert.That(((BlockSyntax)statement.ElseSyntax).Statements, Has.Exactly(2).Items);
+            Assert.That(((BlockSyntax)statement.ElseSyntax!).Statements, Has.Exactly(2).Items);
         }
 
         [Test]
@@ -94,14 +94,14 @@ private void Function()
             Assert.That(statement.ElseSyntax, Is.Not.Null);
             Assert.That(statement.ElseSyntax, Is.InstanceOf<IfStatementSyntax>());
 
-            var elseStatement = (IfStatementSyntax)statement.ElseSyntax;
+            var elseStatement = (IfStatementSyntax)statement.ElseSyntax!;
             Assert.That(elseStatement.ConditionSyntax, Is.InstanceOf<BooleanLiteralSyntax>());
             Assert.That(((BooleanLiteralSyntax)elseStatement.ConditionSyntax).Value, Is.False);
             Assert.That(elseStatement.ThenBlockSyntax, Is.Not.Null);
             Assert.That(elseStatement.ThenBlockSyntax.Statements, Is.Empty);
             Assert.That(elseStatement.ElseSyntax, Is.Not.Null);
             Assert.That(elseStatement.ElseSyntax, Is.InstanceOf<BlockSyntax>());
-            Assert.That(((BlockSyntax)elseStatement.ElseSyntax).Statements, Is.Empty);
+            Assert.That(((BlockSyntax)elseStatement.ElseSyntax!).Statements, Is.Empty);
         }
 
         [Test]

--- a/test/Cle.Parser.UnitTests/SyntaxParserTests/SourceFileTests.cs
+++ b/test/Cle.Parser.UnitTests/SyntaxParserTests/SourceFileTests.cs
@@ -22,7 +22,7 @@ namespace Cle.Parser.UnitTests.SyntaxParserTests
             var syntaxTree = ParseSource(source, out _);
             
             Assert.That(syntaxTree, Is.Not.Null);
-            Assert.That(syntaxTree.Filename, Is.EqualTo("test.cle")); // Default of ParseSource(...)
+            Assert.That(syntaxTree!.Filename, Is.EqualTo("test.cle")); // Default of ParseSource(...)
         }
     }
 }

--- a/test/Cle.Parser.UnitTests/SyntaxParserTests/SyntaxParserTestBase.cs
+++ b/test/Cle.Parser.UnitTests/SyntaxParserTests/SyntaxParserTestBase.cs
@@ -2,7 +2,6 @@ using System;
 using System.Text;
 using Cle.Parser.SyntaxTree;
 using Cle.UnitTests.Common;
-using JetBrains.Annotations;
 using NUnit.Framework;
 
 namespace Cle.Parser.UnitTests.SyntaxParserTests
@@ -12,8 +11,7 @@ namespace Cle.Parser.UnitTests.SyntaxParserTests
         /// <summary>
         /// Parses the given source text and returns the syntax tree if successful.
         /// </summary>
-        [CanBeNull]
-        protected SourceFileSyntax ParseSource([NotNull] string source, out TestingDiagnosticSink diagnostics)
+        protected SourceFileSyntax? ParseSource(string source, out TestingDiagnosticSink diagnostics)
         {
             var sourceBytes = Encoding.UTF8.GetBytes(source);
             diagnostics = new TestingDiagnosticSink();
@@ -24,25 +22,25 @@ namespace Cle.Parser.UnitTests.SyntaxParserTests
         /// <summary>
         /// Parses the given source text and asserts if there were parsing errors.
         /// </summary>
-        [NotNull]
-        protected SourceFileSyntax ParseSourceWithoutDiagnostics([NotNull] string source)
+        protected SourceFileSyntax ParseSourceWithoutDiagnostics(string source)
         {
             var syntaxTree = ParseSource(source, out var diagnostics);
 
             Assert.That(diagnostics.Diagnostics, Is.Empty, "Expected no diagnostics");
             Assert.That(syntaxTree, Is.Not.Null, "Expected non-null syntax tree");
 
-            return syntaxTree;
+            // Due to the previous assert, syntaxTree is now known to be non-null
+            return syntaxTree!;
         }
 
         /// <summary>
         /// Parses the given source text for a full file with exactly one function,
         /// asserts that there were no parsing errors and returns the code block for that function.
         /// </summary>
-        [NotNull]
         protected BlockSyntax ParseBlockForSingleFunction(string source)
         {
             var syntaxTree = ParseSourceWithoutDiagnostics(source);
+
             Assert.That(syntaxTree.Functions, Has.Exactly(1).Items, "File must have only a single function");
             var function = syntaxTree.Functions[0];
 
@@ -53,8 +51,7 @@ namespace Cle.Parser.UnitTests.SyntaxParserTests
         /// Creates and returns a <see cref="SyntaxParser"/> instance for the given source text.
         /// This allows testing instance methods directly.
         /// </summary>
-        [NotNull]
-        protected SyntaxParser GetParserInstance([NotNull] string source, out TestingDiagnosticSink diagnostics)
+        protected SyntaxParser GetParserInstance(string source, out TestingDiagnosticSink diagnostics)
         {
             var sourceBytes = Encoding.UTF8.GetBytes(source);
             diagnostics = new TestingDiagnosticSink();

--- a/test/Cle.SemanticAnalysis.UnitTests/BasicBlockGraphBuilderTests.cs
+++ b/test/Cle.SemanticAnalysis.UnitTests/BasicBlockGraphBuilderTests.cs
@@ -7,6 +7,9 @@ namespace Cle.SemanticAnalysis.UnitTests
 {
     public class BasicBlockGraphBuilderTests
     {
+        // TODO: Re-enable this when refactoring the basic blocks to always be non-null
+#nullable disable
+
         [Test]
         public void Empty_graph_fails()
         {

--- a/test/Cle.SemanticAnalysis.UnitTests/Cle.SemanticAnalysis.UnitTests.csproj
+++ b/test/Cle.SemanticAnalysis.UnitTests/Cle.SemanticAnalysis.UnitTests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <LangVersion>8.0</LangVersion>
+    <NullableContextOptions>enable</NullableContextOptions>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Cle.SemanticAnalysis.UnitTests/Cle.SemanticAnalysis.UnitTests.csproj
+++ b/test/Cle.SemanticAnalysis.UnitTests/Cle.SemanticAnalysis.UnitTests.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Cle.SemanticAnalysis.UnitTests/ExpressionCompilerTests.cs
+++ b/test/Cle.SemanticAnalysis.UnitTests/ExpressionCompilerTests.cs
@@ -661,7 +661,7 @@ namespace Cle.SemanticAnalysis.UnitTests
 
             Assert.That(expressionSyntax, Is.Not.Null);
             Assert.That(diagnostics.Diagnostics, Is.Empty);
-            return expressionSyntax;
+            return expressionSyntax!;
         }
 
         private class TestingResolver : INameResolver

--- a/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/CallTests.cs
+++ b/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/CallTests.cs
@@ -21,7 +21,7 @@ private void VoidMethod() {}";
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             Assert.That(compiledMethod, Is.Not.Null);
             
-            AssertDisassembly(compiledMethod, @"
+            AssertDisassembly(compiledMethod!, @"
 ; #0   void
 ; #1   void
 ; #2   void
@@ -46,7 +46,7 @@ private bool IsLarger(int32 left, int32 right) { return left > right; }";
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             Assert.That(compiledMethod, Is.Not.Null);
             
-            AssertDisassembly(compiledMethod, @"
+            AssertDisassembly(compiledMethod!, @"
 ; #0   int32
 ; #1   int32
 ; #2   bool
@@ -73,7 +73,7 @@ private bool IsLarger(int32 left, int32 right) { return left > right; }";
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             Assert.That(compiledMethod, Is.Not.Null);
             
-            AssertDisassembly(compiledMethod, @"
+            AssertDisassembly(compiledMethod!, @"
 ; #0   int32
 ; #1   int32
 ; #2   bool
@@ -99,7 +99,7 @@ private bool IsLarger(int32 left, int32 right) { return left > right; }";
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             Assert.That(compiledMethod, Is.Not.Null);
             
-            AssertDisassembly(compiledMethod, @"
+            AssertDisassembly(compiledMethod!, @"
 ; #0   int32 param
 ; #1   int32
 ; #2   int32

--- a/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/DeclarationTests.cs
+++ b/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/DeclarationTests.cs
@@ -23,7 +23,7 @@ namespace Cle.SemanticAnalysis.UnitTests.MethodCompilerTests
 
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             Assert.That(result, Is.Not.Null);
-            Assert.That(result.IsEntryPoint, Is.False);
+            Assert.That(result!.IsEntryPoint, Is.False);
             Assert.That(result.ReturnType, Is.EqualTo(SimpleType.Bool));
             Assert.That(result.Visibility, Is.EqualTo(Visibility.Public));
             Assert.That(result.FullName, Is.EqualTo("Namespace::MethodName"));
@@ -46,7 +46,7 @@ namespace Cle.SemanticAnalysis.UnitTests.MethodCompilerTests
 
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             Assert.That(result, Is.Not.Null);
-            Assert.That(result.IsEntryPoint, Is.False);
+            Assert.That(result!.IsEntryPoint, Is.False);
             Assert.That(result.ReturnType, Is.EqualTo(SimpleType.Int32));
             Assert.That(result.Visibility, Is.EqualTo(Visibility.Private));
             Assert.That(result.FullName, Is.EqualTo("long::ns::MethodName"));
@@ -87,7 +87,7 @@ namespace Cle.SemanticAnalysis.UnitTests.MethodCompilerTests
 
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             Assert.That(result, Is.Not.Null);
-            Assert.That(result.ParameterTypes, Has.Exactly(2).Items);
+            Assert.That(result!.ParameterTypes, Has.Exactly(2).Items);
             Assert.That(result.ParameterTypes[0], Is.EqualTo(SimpleType.Int32));
             Assert.That(result.ParameterTypes[1], Is.EqualTo(SimpleType.Bool));
         }
@@ -166,7 +166,7 @@ namespace Cle.SemanticAnalysis.UnitTests.MethodCompilerTests
 
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             Assert.That(result, Is.Not.Null);
-            Assert.That(result.IsEntryPoint, Is.True);
+            Assert.That(result!.IsEntryPoint, Is.True);
         }
 
         [Test]

--- a/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/IfTests.cs
+++ b/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/IfTests.cs
@@ -21,7 +21,7 @@ public bool Contradiction() {
             Assert.That(compiledMethod, Is.Not.Null);
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
-            AssertDisassembly(compiledMethod, @"
+            AssertDisassembly(compiledMethod!, @"
 ; #0   bool
 ; #1   bool
 ; #2   bool
@@ -54,7 +54,7 @@ public bool Tautology() {
             Assert.That(compiledMethod, Is.Not.Null);
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
-            AssertDisassembly(compiledMethod, @"
+            AssertDisassembly(compiledMethod!, @"
 ; #0   bool
 ; #1   bool
 ; #2   bool
@@ -88,7 +88,7 @@ public bool Comparison() {
             Assert.That(compiledMethod, Is.Not.Null);
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
-            AssertDisassembly(compiledMethod, @"
+            AssertDisassembly(compiledMethod!, @"
 ; #0   int32
 ; #1   int32
 ; #2   bool
@@ -128,7 +128,7 @@ public int32 TheAnswer() {
 
             // BB_2 exists because direct BB_0 --> BB_3 would be a critical edge: BB_0 has two successors
             // and BB_3 has two predecessors. This causes issues for SSA because the PHI cannot be resolved.
-            AssertDisassembly(compiledMethod, @"
+            AssertDisassembly(compiledMethod!, @"
 ; #0   int32
 ; #1   bool
 ; #2   int32
@@ -169,7 +169,7 @@ public int32 ComplexAnswer() {
 
             // Here are no critical edges as BB_1 and BB_2, the predecessors of BB_3, have only a single
             // successor each, and no other block has two predecessors.
-            AssertDisassembly(compiledMethod, @"
+            AssertDisassembly(compiledMethod!, @"
 ; #0   int32
 ; #1   bool
 ; #2   int32
@@ -209,7 +209,7 @@ public int32 GetTheAnswer() {
             Assert.That(compiledMethod, Is.Not.Null);
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
-            AssertDisassembly(compiledMethod, @"
+            AssertDisassembly(compiledMethod!, @"
 ; #0   bool
 ; #1   bool
 ; #2   int32
@@ -256,7 +256,7 @@ public int32 GetTheAnswer() {
             Assert.That(compiledMethod, Is.Not.Null);
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
-            AssertDisassembly(compiledMethod, @"
+            AssertDisassembly(compiledMethod!, @"
 ; #0   bool
 ; #1   bool
 ; #2   int32
@@ -307,7 +307,7 @@ public int32 TheAnswer() {
             Assert.That(compiledMethod, Is.Not.Null);
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
-            AssertDisassembly(compiledMethod, @"
+            AssertDisassembly(compiledMethod!, @"
 ; #0   bool
 ; #1   int32
 ; #2   bool
@@ -358,7 +358,7 @@ public int32 TheAnswer() {
             Assert.That(diagnostics.Diagnostics, Is.Empty);
 
             // Although BB_5 has two predecessors, the edges are not critical since BB_1 and BB_3 do not branch
-            AssertDisassembly(compiledMethod, @"
+            AssertDisassembly(compiledMethod!, @"
 ; #0   int32
 ; #1   bool
 ; #2   int32
@@ -411,7 +411,7 @@ public int32 TheAnswer() {
             Assert.That(compiledMethod, Is.Not.Null);
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
-            AssertDisassembly(compiledMethod, @"
+            AssertDisassembly(compiledMethod!, @"
 ; #0   bool
 ; #1   int32
 ; #2   bool

--- a/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/MethodCompilerTestBase.cs
+++ b/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/MethodCompilerTestBase.cs
@@ -3,7 +3,6 @@ using System.Text;
 using Cle.Parser;
 using Cle.SemanticAnalysis.IR;
 using Cle.UnitTests.Common;
-using JetBrains.Annotations;
 using NUnit.Framework;
 
 namespace Cle.SemanticAnalysis.UnitTests.MethodCompilerTests
@@ -14,8 +13,8 @@ namespace Cle.SemanticAnalysis.UnitTests.MethodCompilerTests
         /// Parses the given source code, compiles the method declarations and
         /// returns the result of <see cref="MethodCompiler.CompileBody"/> on the first method.
         /// </summary>
-        protected CompiledMethod TryCompileFirstMethod([NotNull] string source,
-            [NotNull] out TestingDiagnosticSink diagnostics)
+        protected CompiledMethod? TryCompileFirstMethod(string source,
+            out TestingDiagnosticSink diagnostics)
         {
             var sourceBytes = Encoding.UTF8.GetBytes(source);
             diagnostics = new TestingDiagnosticSink();
@@ -27,8 +26,8 @@ namespace Cle.SemanticAnalysis.UnitTests.MethodCompilerTests
 
             // Parse the declarations
             var declarationProvider = new TestingSingleFileDeclarationProvider();
-            MethodDeclaration firstDeclaration = null;
-            foreach (var functionSyntax in syntaxTree.Functions)
+            MethodDeclaration? firstDeclaration = null;
+            foreach (var functionSyntax in syntaxTree!.Functions)
             {
                 var declaration = MethodCompiler.CompileDeclaration(functionSyntax, syntaxTree.Namespace, sourceFilename,
                     declarationProvider.Methods.Count, declarationProvider, diagnostics);
@@ -39,19 +38,21 @@ namespace Cle.SemanticAnalysis.UnitTests.MethodCompilerTests
                 {
                     firstDeclaration = declaration;
                 }
-                declarationProvider.Methods.Add(functionSyntax.Name, declaration);
+                declarationProvider.Methods.Add(functionSyntax.Name, declaration!);
             }
+
+            Assert.That(firstDeclaration, Is.Not.Null, "No methods were declared.");
 
             // Then compile the first method
             return new MethodCompiler(declarationProvider, diagnostics)
-                .CompileBody(syntaxTree.Functions[0], firstDeclaration, syntaxTree.Namespace, sourceFilename);
+                .CompileBody(syntaxTree.Functions[0], firstDeclaration!, syntaxTree.Namespace, sourceFilename);
         }
         
         /// <summary>
         /// Verifies that the method has disassembly equal to <paramref name="expected"/>.
         /// Both the actual and expected strings are trimmed and linefeed normalized.
         /// </summary>
-        protected void AssertDisassembly([NotNull] CompiledMethod compiledMethod, [NotNull] string expected)
+        protected void AssertDisassembly(CompiledMethod compiledMethod, string expected)
         {
             var builder = new StringBuilder();
             MethodDisassembler.Disassemble(compiledMethod, builder);

--- a/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/ReturnTests.cs
+++ b/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/ReturnTests.cs
@@ -15,7 +15,7 @@ public bool ReturnTrue() { return true; }";
             Assert.That(compiledMethod, Is.Not.Null);
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
-            AssertDisassembly(compiledMethod, @"
+            AssertDisassembly(compiledMethod!, @"
 ; #0   bool
 BB_0:
     Load true -> #0
@@ -32,7 +32,7 @@ public int32 GetTheAnswer() { return 42; }";
             Assert.That(compiledMethod, Is.Not.Null);
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
-            AssertDisassembly(compiledMethod, @"
+            AssertDisassembly(compiledMethod!, @"
 ; #0   int32
 BB_0:
     Load 42 -> #0
@@ -49,7 +49,7 @@ public int32 GetTheAnswer() { return 40 + 2; }";
             Assert.That(compiledMethod, Is.Not.Null);
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
-            AssertDisassembly(compiledMethod, @"
+            AssertDisassembly(compiledMethod!, @"
 ; #0   int32
 BB_0:
     Load 42 -> #0
@@ -66,7 +66,7 @@ public int32 GetTheAnswer() { int32 almost = 40; return almost + 2; }";
             Assert.That(compiledMethod, Is.Not.Null);
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
-            AssertDisassembly(compiledMethod, @"
+            AssertDisassembly(compiledMethod!, @"
 ; #0   int32
 ; #1   int32
 ; #2   int32
@@ -87,7 +87,7 @@ public void DoNothing() { return; }";
             Assert.That(compiledMethod, Is.Not.Null);
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
-            AssertDisassembly(compiledMethod, @"
+            AssertDisassembly(compiledMethod!, @"
 ; #0   void
 BB_0:
     Return #0");
@@ -103,7 +103,7 @@ public void DoNothing() { }";
             Assert.That(compiledMethod, Is.Not.Null);
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
-            AssertDisassembly(compiledMethod, @"
+            AssertDisassembly(compiledMethod!, @"
 ; #0   void
 BB_0:
     Return #0");
@@ -119,7 +119,7 @@ public void DoNothing() { if (true) { return; } }";
             Assert.That(compiledMethod, Is.Not.Null);
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
-            AssertDisassembly(compiledMethod, @"
+            AssertDisassembly(compiledMethod!, @"
 ; #0   bool
 ; #1   void
 ; #2   void

--- a/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/VariableTests.cs
+++ b/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/VariableTests.cs
@@ -19,7 +19,7 @@ public void DoNothing() {
             Assert.That(compiledMethod, Is.Not.Null);
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
-            AssertDisassembly(compiledMethod, @"
+            AssertDisassembly(compiledMethod!, @"
 ; #0   int32
 ; #1   void
 BB_0:
@@ -42,7 +42,7 @@ public void DoNothing() {
             Assert.That(compiledMethod, Is.Not.Null);
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
-            AssertDisassembly(compiledMethod, @"
+            AssertDisassembly(compiledMethod!, @"
 ; #0   int32
 ; #1   int32
 ; #2   void
@@ -68,7 +68,7 @@ public void DoNothing() {
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
             // void will be used for the initial value
-            AssertDisassembly(compiledMethod, @"
+            AssertDisassembly(compiledMethod!, @"
 ; #0   int32
 ; #1   int32
 ; #2   void
@@ -217,7 +217,7 @@ public void NameAppearsTwice() {
             Assert.That(compiledMethod, Is.Not.Null);
             Assert.That(diagnostics.Diagnostics, Is.Empty);
 
-            AssertDisassembly(compiledMethod, @"
+            AssertDisassembly(compiledMethod!, @"
 ; #0   int32
 ; #1   int32
 ; #2   void
@@ -246,7 +246,7 @@ public void NameAppearsTwice() {
             Assert.That(compiledMethod, Is.Not.Null);
             Assert.That(diagnostics.Diagnostics, Is.Empty);
 
-            AssertDisassembly(compiledMethod, @"
+            AssertDisassembly(compiledMethod!, @"
 ; #0   int32
 ; #1   int32
 ; #2   void
@@ -269,7 +269,7 @@ public int32 Params(int32 first, bool second) {
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             Assert.That(compiledMethod, Is.Not.Null);
 
-            AssertDisassembly(compiledMethod, @"
+            AssertDisassembly(compiledMethod!, @"
 ; #0   int32 param
 ; #1   bool param
 ; #2   int32

--- a/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/WhileTests.cs
+++ b/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/WhileTests.cs
@@ -19,7 +19,7 @@ public bool Stupid() {
             Assert.That(compiledMethod, Is.Not.Null);
             Assert.That(diagnostics.Diagnostics, Is.Empty);
             
-            AssertDisassembly(compiledMethod, @"
+            AssertDisassembly(compiledMethod!, @"
 ; #0   bool
 ; #1   bool
 BB_0:
@@ -56,7 +56,7 @@ public bool Stupid() {
             
             // The empty BB_4 must exist because otherwise the BB_2 --> BB_5 edge would be critical:
             // BB_2 has two successors and BB_5 has two predecessors (BB_3, and BB_2 via BB_4).
-            AssertDisassembly(compiledMethod, @"
+            AssertDisassembly(compiledMethod!, @"
 ; #0   bool
 ; #1   bool
 ; #2   bool

--- a/test/Cle.UnitTests.Common/Cle.UnitTests.Common.csproj
+++ b/test/Cle.UnitTests.Common/Cle.UnitTests.Common.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <LangVersion>8.0</LangVersion>
+    <NullableContextOptions>enable</NullableContextOptions>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Cle.UnitTests.Common/Cle.UnitTests.Common.csproj
+++ b/test/Cle.UnitTests.Common/Cle.UnitTests.Common.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Cle.UnitTests.Common/DiagnosticAssertResult.cs
+++ b/test/Cle.UnitTests.Common/DiagnosticAssertResult.cs
@@ -1,5 +1,4 @@
 ﻿using Cle.Common;
-using JetBrains.Annotations;
 using NUnit.Framework;
 
 namespace Cle.UnitTests.Common
@@ -9,10 +8,9 @@ namespace Cle.UnitTests.Common
     /// </summary>
     public class DiagnosticAssertResult
     {
-        [NotNull]
         private readonly Diagnostic _diagnostic;
 
-        public DiagnosticAssertResult([NotNull] Diagnostic diagnostic)
+        public DiagnosticAssertResult(Diagnostic diagnostic)
         {
             _diagnostic = diagnostic;
         }
@@ -21,7 +19,7 @@ namespace Cle.UnitTests.Common
         /// Asserts that <see cref="Diagnostic.Actual"/> for this diagnostic
         /// is equal to <paramref name="expectedActual"/>.
         /// </summary>
-        public DiagnosticAssertResult WithActual([CanBeNull] string expectedActual)
+        public DiagnosticAssertResult WithActual(string? expectedActual)
         {
             Assert.That(_diagnostic.Actual, Is.EqualTo(expectedActual));
 
@@ -42,7 +40,7 @@ namespace Cle.UnitTests.Common
         /// Asserts that <see cref="Diagnostic.Expected"/> for this diagnostic
         /// is equal to <paramref name="expectedExpected"/>.
         /// </summary>
-        public DiagnosticAssertResult WithExpected([CanBeNull] string expectedExpected)
+        public DiagnosticAssertResult WithExpected(string? expectedExpected)
         {
             Assert.That(_diagnostic.Expected, Is.EqualTo(expectedExpected));
 

--- a/test/Cle.UnitTests.Common/MethodAssembler.cs
+++ b/test/Cle.UnitTests.Common/MethodAssembler.cs
@@ -4,7 +4,6 @@ using System.Collections.Immutable;
 using Cle.Common.TypeSystem;
 using Cle.SemanticAnalysis;
 using Cle.SemanticAnalysis.IR;
-using JetBrains.Annotations;
 using NUnit.Framework;
 
 namespace Cle.UnitTests.Common
@@ -18,11 +17,11 @@ namespace Cle.UnitTests.Common
         /// Creates a <see cref="CompiledMethod"/> out of the given IR disassembly,
         /// which must follow the <see cref="MethodDisassembler"/> output very closely.
         /// </summary>
-        public static CompiledMethod Assemble([NotNull] string source, [NotNull] string fullName)
+        public static CompiledMethod Assemble(string source, string fullName)
         {
             var method = new CompiledMethod(fullName);
             var graphBuilder = new BasicBlockGraphBuilder();
-            BasicBlockBuilder currentBlockBuilder = null;
+            BasicBlockBuilder? currentBlockBuilder = null;
             var calledMethodIndices = new Dictionary<string, int>();
             
             // Since this class is for testing purposes only, we use brittle and unperformant string splits
@@ -65,8 +64,8 @@ namespace Cle.UnitTests.Common
                     // The line is of form "==> BB_nnn"
                     var blockIndex = int.Parse(currentLine.AsSpan(7));
 
-                    Assert.That(currentBlockBuilder, Is.Not.Null);
-                    currentBlockBuilder.SetSuccessor(blockIndex);
+                    Assert.That(currentBlockBuilder, Is.Not.Null, "No basic block has been started.");
+                    currentBlockBuilder!.SetSuccessor(blockIndex);
                 }
                 else if (currentLine.StartsWith("PHI"))
                 {
@@ -86,13 +85,13 @@ namespace Cle.UnitTests.Common
                     var dest = phiBuilder[phiBuilder.Count - 1];
                     phiBuilder.RemoveAt(phiBuilder.Count - 1);
                     
-                    currentBlockBuilder.AddPhi(dest, phiBuilder.ToImmutable());
+                    currentBlockBuilder!.AddPhi(dest, phiBuilder.ToImmutable());
                 }
                 else
                 {
                     Assert.That(currentBlockBuilder, Is.Not.Null, "No basic block has been started.");
 
-                    ParseInstruction(currentLine, method, currentBlockBuilder, calledMethodIndices);
+                    ParseInstruction(currentLine, method, currentBlockBuilder!, calledMethodIndices);
                 }
             }
 

--- a/test/Cle.UnitTests.Common/TestingDiagnosticSink.cs
+++ b/test/Cle.UnitTests.Common/TestingDiagnosticSink.cs
@@ -1,19 +1,14 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Cle.Common;
-using JetBrains.Annotations;
 using NUnit.Framework;
 
 namespace Cle.UnitTests.Common
 {
     public class TestingDiagnosticSink : IDiagnosticSink
     {
-        [NotNull]
-        [ItemNotNull]
         public IReadOnlyList<Diagnostic> Diagnostics => _diagnostics;
         
-        [NotNull]
-        [ItemNotNull]
         private readonly List<Diagnostic> _diagnostics = new List<Diagnostic>();
 
         public void Add(DiagnosticCode code, TextPosition position)
@@ -23,14 +18,14 @@ namespace Cle.UnitTests.Common
             _diagnostics.Add(diagnostic);
         }
 
-        public void Add(DiagnosticCode code, TextPosition position, string actual)
+        public void Add(DiagnosticCode code, TextPosition position, string? actual)
         {
             var diagnostic = new Diagnostic(code, position, string.Empty, string.Empty, actual, null);
 
             _diagnostics.Add(diagnostic);
         }
 
-        public void Add(DiagnosticCode code, TextPosition position, string actual, string expected)
+        public void Add(DiagnosticCode code, TextPosition position, string? actual, string? expected)
         {
             var diagnostic = new Diagnostic(code, position, string.Empty, string.Empty, actual, expected);
 


### PR DESCRIPTION
The broadest part of #51: updated all projects to use the new nullable reference types feature, and removed all references to `JetBrains.Annotations`.