### PR TITLE
Drop unreachable basic blocks in graph builder

### DIFF
--- a/src/Cle.CodeGeneration/LoweringX64.cs
+++ b/src/Cle.CodeGeneration/LoweringX64.cs
@@ -34,19 +34,7 @@ namespace Cle.CodeGeneration
             for (var i = 0; i < highMethod.Body.BasicBlocks.Count; i++)
             {
                 var highBlock = highMethod.Body.BasicBlocks[i];
-
-                if (highBlock is null)
-                {
-                    lowMethod.Blocks.Add(new LowBlock()
-                    {
-                        Predecessors = Array.Empty<int>(),
-                        Successors = Array.Empty<int>()
-                    });
-                }
-                else
-                {
-                    lowMethod.Blocks.Add(ConvertBlock(highBlock, highMethod, lowMethod, i == 0, paramCount));
-                }
+                lowMethod.Blocks.Add(ConvertBlock(highBlock, highMethod, lowMethod, i == 0, paramCount));
             }
 
             return lowMethod;

--- a/src/Cle.SemanticAnalysis/IR/BasicBlockGraph.cs
+++ b/src/Cle.SemanticAnalysis/IR/BasicBlockGraph.cs
@@ -7,9 +7,9 @@ namespace Cle.SemanticAnalysis.IR
     /// </summary>
     public class BasicBlockGraph
     {
-        public readonly ImmutableList<BasicBlock?> BasicBlocks;
+        public readonly ImmutableList<BasicBlock> BasicBlocks;
 
-        public BasicBlockGraph(ImmutableList<BasicBlock?> basicBlocks)
+        public BasicBlockGraph(ImmutableList<BasicBlock> basicBlocks)
         {
             BasicBlocks = basicBlocks;
         }

--- a/src/Cle.SemanticAnalysis/MethodDisassembler.cs
+++ b/src/Cle.SemanticAnalysis/MethodDisassembler.cs
@@ -38,10 +38,7 @@ namespace Cle.SemanticAnalysis
 
             for (var blockIndex = 0; blockIndex < method.Body.BasicBlocks.Count; blockIndex++)
             {
-                // The block may be null as the builder omits dead blocks but preserves numbering
                 var block = method.Body.BasicBlocks[blockIndex];
-                if (block is null)
-                    continue;
 
                 // Basic block header
                 outputBuilder.AppendLine("BB_" + blockIndex + ":");

--- a/src/Cle.SemanticAnalysis/SsaConverter.cs
+++ b/src/Cle.SemanticAnalysis/SsaConverter.cs
@@ -106,10 +106,6 @@ namespace Cle.SemanticAnalysis
         {
             Debug.Assert(_originalMethod.Body != null);
             var block = _originalMethod.Body.BasicBlocks[blockIndex];
-            
-            // Unreachable blocks are easy to convert!
-            if (block is null)
-                return;
 
             // If possible, seal this block
             TrySealBlock(blockIndex);
@@ -215,7 +211,6 @@ namespace Cle.SemanticAnalysis
             {
                 Debug.Assert(_originalMethod.Body != null);
                 var block = _originalMethod.Body.BasicBlocks[blockIndex];
-                Debug.Assert(block != null);
 
                 if (!_isSealed[blockIndex])
                 {
@@ -271,7 +266,6 @@ namespace Cle.SemanticAnalysis
         {
             Debug.Assert(_originalMethod.Body != null);
             var block = _originalMethod.Body.BasicBlocks[blockIndex];
-            Debug.Assert(block != null);
 
             var operands = ImmutableList<int>.Empty.ToBuilder();
             foreach (var predecessor in block.Predecessors)
@@ -327,7 +321,7 @@ namespace Cle.SemanticAnalysis
 
             // TODO Perf: making the precondition check inline-able might have a positive impact
             if (!_isSealed[blockIndex] &&
-                _originalMethod.Body.BasicBlocks[blockIndex]?.Predecessors.Count == _predecessorsSet[blockIndex])
+                _originalMethod.Body.BasicBlocks[blockIndex].Predecessors.Count == _predecessorsSet[blockIndex])
             {
                 _isSealed[blockIndex] = true;
 

--- a/test/Cle.CodeGeneration.UnitTests/Lowering/BranchLoweringX64Tests.cs
+++ b/test/Cle.CodeGeneration.UnitTests/Lowering/BranchLoweringX64Tests.cs
@@ -108,33 +108,5 @@ LB_2:
 ";
             AssertDump(lowered, expected);
         }
-
-        [Test]
-        public void Empty_block_is_properly_lowered()
-        {
-            const string source = @"
-; #0 void
-BB_0:
-    Return #0
-BB_1:
-";
-            var method = MethodAssembler.Assemble(source, "Test::Method");
-            var lowered = LoweringX64.Lower(method);
-
-            const string expected = @"
-; #0 void [?]
-; #1 void [rax]
-LB_0:
-    LoadInt 0 0 0 -> 1
-    Return 1 0 0 -> 0
-LB_1:
-";
-            AssertDump(lowered, expected);
-
-            Assert.That(lowered.Blocks[0].Predecessors, Is.Empty);
-            Assert.That(lowered.Blocks[1].Predecessors, Is.Empty);
-            Assert.That(lowered.Blocks[0].Successors, Is.Empty);
-            Assert.That(lowered.Blocks[1].Successors, Is.Empty);
-        }
     }
 }

--- a/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/IfTests.cs
+++ b/test/Cle.SemanticAnalysis.UnitTests/MethodCompilerTests/IfTests.cs
@@ -218,7 +218,7 @@ public int32 GetTheAnswer() {
 BB_0:
     Load true -> #0
     BranchIf #0 ==> BB_1
-    ==> BB_5
+    ==> BB_4
 
 BB_1:
     Load false -> #1
@@ -233,7 +233,7 @@ BB_3:
     Load 42 -> #3
     Return #3
 
-BB_5:
+BB_4:
     Load 41 -> #4
     Return #4");
         }
@@ -268,7 +268,7 @@ BB_0:
     ==> BB_2
 
 BB_1:
-    ==> BB_6
+    ==> BB_5
 
 BB_2:
     Load false -> #1
@@ -283,7 +283,7 @@ BB_4:
     Load 42 -> #3
     Return #3
 
-BB_6:
+BB_5:
     Load 41 -> #4
     Return #4");
         }

--- a/test/Cle.SemanticAnalysis.UnitTests/SsaConverterTests.cs
+++ b/test/Cle.SemanticAnalysis.UnitTests/SsaConverterTests.cs
@@ -186,37 +186,6 @@ BB_1:
         }
 
         [Test]
-        public void Successive_basic_blocks_with_gap_in_between()
-        {
-            const string source = @"
-; #0   int32 param
-BB_0:
-    Multiply #0 * #0 -> #0
-    ==> BB_2
-
-BB_2:
-    Add #0 + #0 -> #0
-    Return #0
-";
-            var original = MethodAssembler.Assemble(source, "Test::Method");
-            var result = new SsaConverter().ConvertToSsa(original);
-
-            const string expected = @"
-; #0   int32 param
-; #1   int32
-; #2   int32
-BB_0:
-    Multiply #0 * #0 -> #1
-    ==> BB_2
-
-BB_2:
-    Add #1 + #1 -> #2
-    Return #2
-";
-            AssertDisassembly(result, expected);
-        }
-
-        [Test]
         public void Branch_that_does_not_merge_back()
         {
             const string source = @"

--- a/test/Cle.UnitTests.Common/MethodAssembler.cs
+++ b/test/Cle.UnitTests.Common/MethodAssembler.cs
@@ -51,11 +51,7 @@ namespace Cle.UnitTests.Common
                     // The line is of form "BB_nnn:" so we have to chop bits off both ends
                     var blockIndex = int.Parse(currentLine.AsSpan(3, currentLine.Length - 4));
                     
-                    // Blocks may be omitted in the disassembly, so we may need to create the missing ones too
-                    while (currentBlockBuilder == null || currentBlockBuilder.Index < blockIndex)
-                    {
-                        currentBlockBuilder = graphBuilder.GetNewBasicBlock();
-                    }
+                    currentBlockBuilder = graphBuilder.GetNewBasicBlock();
                     Assert.That(blockIndex, Is.EqualTo(currentBlockBuilder.Index), "Blocks must be specified in order.");
                 }
                 else if (currentLine.StartsWith("==>"))


### PR DESCRIPTION
Fixes #42. The title says it all: from now on there will not be gaps in the basic block list.