### PR TITLE
Implement immediate forms of some LIR instructions

### DIFF
--- a/src/Cle.CodeGeneration/Lir/LowInstruction.cs
+++ b/src/Cle.CodeGeneration/Lir/LowInstruction.cs
@@ -137,12 +137,14 @@ namespace Cle.CodeGeneration.Lir
         /// Shifts the Left local left by the amount specified in the Right local (modulo operand size)
         /// and stores the result in the Dest local.
         /// The Right local must be stored in the platform-specified location.
+        /// If Right == -1, the shift amount is a constant stored in Data instead.
         /// </summary>
         ShiftLeft,
         /// <summary>
         /// Shifts the Left local right by the amount specified in the Right local (modulo operand size),
         /// propagating the sign bit, and stores the result in the Dest local.
         /// The Right local must be stored in the platform-specified location.
+        /// If Right == -1, the shift amount is a constant stored in Data instead.
         /// </summary>
         ShiftArithmeticRight,
         /// <summary>
@@ -173,6 +175,8 @@ namespace Cle.CodeGeneration.Lir
 
         /// <summary>
         /// Compares Left and Right and stores the result in processor flags.
+        /// If Right == -1, the value of the Left local is compared against Data (width specified by Left,
+        /// at most 4 bytes, sign-extended to 8 if necessary).
         /// </summary>
         Compare,
         /// <summary>

--- a/src/Cle.CodeGeneration/Lir/LowInstruction.cs
+++ b/src/Cle.CodeGeneration/Lir/LowInstruction.cs
@@ -110,14 +110,17 @@ namespace Cle.CodeGeneration.Lir
 
         /// <summary>
         /// Sums the Left and Right locals and stores the result in Dest local.
+        /// If Right == -1, a constant in Data is used instead (at most 4 bytes, sign-extended to 8 if necessary).
         /// </summary>
         IntegerAdd,
         /// <summary>
         /// Subtracts the Right local from the Left local and stores the result in Dest local.
+        /// If Right == -1, a constant in Data is used instead (at most 4 bytes, sign-extended to 8 if necessary).
         /// </summary>
         IntegerSubtract,
         /// <summary>
         /// Multiplies the Left and Right locals and stores the result in Dest local.
+        /// If Right == -1, a constant in Data is used instead (at most 4 bytes, sign-extended to 8 if necessary).
         /// </summary>
         IntegerMultiply,
         /// <summary>

--- a/src/Cle.CodeGeneration/PeepholeOptimizer.cs
+++ b/src/Cle.CodeGeneration/PeepholeOptimizer.cs
@@ -181,6 +181,7 @@ namespace Cle.CodeGeneration
                 if (IsArithmeticWithImmediateLeft(next.Op) && current.Dest == next.Left)
                 {
                     // When #2 is used only once, and the arithmetic operation is commutative
+                    // (That is, subtraction and compare are left out.)
                     // ----
                     // Load 1234 -> #2
                     // Arithmetic #2 #1 -> #3
@@ -258,12 +259,12 @@ namespace Cle.CodeGeneration
         private static bool ValueIsAtMost4Bytes(ulong value)
         {
             // Take the sign extension into account
-            return (long)value >= int.MinValue && value <= int.MaxValue;
+            return (long)value >= int.MinValue && (long)value <= int.MaxValue;
         }
 
         private static bool IsArithmeticWithImmediateRight(LowOp op)
         {
-            return op == LowOp.IntegerAdd || op == LowOp.IntegerSubtract || op == LowOp.IntegerMultiply;
+            return op == LowOp.IntegerAdd || op == LowOp.IntegerSubtract || op == LowOp.IntegerMultiply || op == LowOp.Compare;
         }
 
         private static bool IsArithmeticWithImmediateLeft(LowOp op)

--- a/src/Cle.CodeGeneration/WindowsX64CodeGenerator.cs
+++ b/src/Cle.CodeGeneration/WindowsX64CodeGenerator.cs
@@ -405,9 +405,18 @@ namespace Cle.CodeGeneration
             var (destLocation, destLocalIndex) = allocation.Get(inst.Dest);
             var operandSize = method.Locals[destLocalIndex].Type.SizeInBytes;
 
-            // The same logic as for unary operations, since the shift amount is in rcx
-            if (srcLocation == destLocation)
+            if (inst.Right == -1)
             {
+                // Shift by a constant
+                if (srcLocation != destLocation)
+                {
+                    emitter.EmitMov(destLocation, srcLocation, operandSize);
+                }
+                emitter.EmitShiftWithImmediate(shiftType, destLocation, (int)inst.Data, operandSize);
+            }
+            else if (srcLocation == destLocation)
+            {
+                // Non-constant amount: the same logic as for unary operations, since the shift amount is in rcx
                 emitter.EmitShift(shiftType, srcLocation, operandSize);
             }
             else

--- a/src/Cle.CodeGeneration/WindowsX64CodeGenerator.cs
+++ b/src/Cle.CodeGeneration/WindowsX64CodeGenerator.cs
@@ -215,7 +215,16 @@ namespace Cle.CodeGeneration
                             var leftLocal = method.Locals[leftLocalIndex];
                             var operandSize = leftLocal.Type.Equals(SimpleType.Bool) ? 4 : leftLocal.Type.SizeInBytes;
 
-                            emitter.EmitCmp(leftLocation, allocation.Get(inst.Right).location, operandSize);
+                            if (inst.Right == -1)
+                            {
+                                // Comparison with a constant
+                                emitter.EmitCmpWithImmediate(leftLocation, (int)inst.Data, operandSize);
+                            }
+                            else
+                            {
+                                // Comparison with another local
+                                emitter.EmitCmp(leftLocation, allocation.Get(inst.Right).location, operandSize);
+                            }
                             break;
                         }
                     case LowOp.Test:

--- a/test/Cle.CodeGeneration.UnitTests/X64CodeGenerator/BranchTests.cs
+++ b/test/Cle.CodeGeneration.UnitTests/X64CodeGenerator/BranchTests.cs
@@ -40,8 +40,7 @@ BB_2:
 ; Test::Method
 LB_0:
     mov ecx, 0x2A
-    mov edx, 0x64
-    cmp ecx, edx
+    cmp ecx, 0x64
     {expectedConditionalJump} LB_1
     jmp LB_2
 LB_1:
@@ -92,8 +91,7 @@ BB_2:
 ; Test::Method
 LB_0:
     mov ecx, 0x2A
-    mov edx, 0x64
-    cmp ecx, edx
+    cmp ecx, 0x64
     {expectedConditionalJump} LB_1
     jmp LB_2
 LB_1:

--- a/test/Cle.CodeGeneration.UnitTests/X64CodeGenerator/BranchTests.cs
+++ b/test/Cle.CodeGeneration.UnitTests/X64CodeGenerator/BranchTests.cs
@@ -39,7 +39,7 @@ BB_2:
             var expected = $@"
 ; Test::Method
 LB_0:
-    mov ecx, 0x2A
+    mov ecx, 0x0000002A
     cmp ecx, 0x64
     {expectedConditionalJump} LB_1
     jmp LB_2
@@ -47,7 +47,7 @@ LB_1:
     xor eax, eax
     ret
 LB_2:
-    mov eax, 0x1
+    mov eax, 0x00000001
     ret
 ";
             EmitAndAssertDisassembly(source, expected);
@@ -90,7 +90,7 @@ BB_2:
             var expected = $@"
 ; Test::Method
 LB_0:
-    mov ecx, 0x2A
+    mov ecx, 0x0000002A
     cmp ecx, 0x64
     {expectedConditionalJump} LB_1
     jmp LB_2
@@ -98,7 +98,7 @@ LB_1:
     xor eax, eax
     ret
 LB_2:
-    mov eax, 0x1
+    mov eax, 0x00000001
     ret
 ";
             EmitAndAssertDisassembly(source, expected);
@@ -133,7 +133,7 @@ BB_2:
             const string expected = @"
 ; Test::Method
 LB_0:
-    mov ecx, 0x1
+    mov ecx, 0x00000001
     test ecx, ecx
     jne LB_1
     jmp LB_2
@@ -141,7 +141,7 @@ LB_1:
     xor eax, eax
     ret
 LB_2:
-    mov eax, 0x1
+    mov eax, 0x00000001
     ret
 ";
             EmitAndAssertDisassembly(source, expected);
@@ -178,7 +178,7 @@ BB_2:
             const string expected = @"
 ; Test::Method
 LB_0:
-    mov ecx, 0x1
+    mov ecx, 0x00000001
     test ecx, ecx
     je LB_1
     jmp LB_2
@@ -186,7 +186,7 @@ LB_1:
     xor eax, eax
     ret
 LB_2:
-    mov eax, 0x1
+    mov eax, 0x00000001
     ret
 ";
             EmitAndAssertDisassembly(source, expected);
@@ -229,12 +229,12 @@ BB_3:
 ; Test::Method
 LB_0:
     xor ecx, ecx
-    mov edx, 0x1
+    mov edx, 0x00000001
     test edx, edx
     jne LB_1
     jmp LB_2
 LB_1:
-    mov ecx, 0x1
+    mov ecx, 0x00000001
     jmp LB_3
 LB_2:
 LB_3:

--- a/test/Cle.CodeGeneration.UnitTests/X64CodeGenerator/CallTests.cs
+++ b/test/Cle.CodeGeneration.UnitTests/X64CodeGenerator/CallTests.cs
@@ -75,8 +75,8 @@ BB_0:
 ; Test::Method
 LB_0:
     sub rsp, 0x28
-    mov ecx, 0x1
-    mov edx, 0x1
+    mov ecx, 0x00000001
+    mov edx, 0x00000001
     call Test::DoSomething
     xor eax, eax
     add rsp, 0x28

--- a/test/Cle.CodeGeneration.UnitTests/X64CodeGenerator/VariableTests.cs
+++ b/test/Cle.CodeGeneration.UnitTests/X64CodeGenerator/VariableTests.cs
@@ -168,6 +168,8 @@ LB_0:
         [TestCase("Add", "add")]
         [TestCase("Subtract", "sub")]
         [TestCase("Multiply", "imul")]
+        [TestCase("ShiftLeft", "shl")]
+        [TestCase("ShiftRight", "sar")]
         public void Basic_int32_arithmetic_with_immediate_right(string highOp, string expectedAsmOp)
         {
             // private int32 F(int32 value) { return value {op} 7; }

--- a/test/Cle.CodeGeneration.UnitTests/X64CodeGenerator/VariableTests.cs
+++ b/test/Cle.CodeGeneration.UnitTests/X64CodeGenerator/VariableTests.cs
@@ -189,6 +189,30 @@ LB_0:
 ";
             EmitAndAssertDisassembly(source, expected);
         }
+
+        [TestCase("Add", "add")]
+        [TestCase("Multiply", "imul")]
+        public void Basic_int32_arithmetic_with_immediate_left(string highOp, string expectedAsmOp)
+        {
+            // private int32 F(int32 value) { return 7 {op} value; }
+            var source = $@"
+; #0   int32 param
+; #1   int32
+; #2   int32
+BB_0:
+    Load 7 -> #1
+    {highOp} #1 ? #0 -> #2
+    Return #2
+";
+            var expected = $@"
+; Test::Method
+LB_0:
+    {expectedAsmOp} ecx, 0x7
+    mov eax, ecx
+    ret
+";
+            EmitAndAssertDisassembly(source, expected);
+        }
         
         [TestCase("Subtract", "sub")]
         public void Basic_non_commutative_int32_arithmetic(string highOp, string expectedAsmOp)

--- a/test/Cle.CodeGeneration.UnitTests/X64CodeGenerator/VariableTests.cs
+++ b/test/Cle.CodeGeneration.UnitTests/X64CodeGenerator/VariableTests.cs
@@ -4,20 +4,20 @@ namespace Cle.CodeGeneration.UnitTests.X64CodeGenerator
 {
     public class VariableTests : X64CodeGeneratorTestBase
     {
-        [Test]
-        public void Constant_integer_load_and_return()
+        [TestCase(42, "mov eax, 0x0000002A")]
+        [TestCase(-1, "mov rax, 0xFFFFFFFF")] // Sign-extended to full 64 bits
+        public void Constant_integer_load_and_return(int value, string expectedInstruction)
         {
-            // return 42;
-            const string source = @"
+            var source = $@"
 ; #0   int32
 BB_0:
-    Load 42 -> #0
+    Load {value} -> #0
     Return #0
 ";
-            const string expected = @"
+            var expected = $@"
 ; Test::Method
 LB_0:
-    mov eax, 0x2A
+    {expectedInstruction}
     ret
 ";
             EmitAndAssertDisassembly(source, expected);
@@ -127,8 +127,8 @@ BB_0:
             const string expected = @"
 ; Test::Method
 LB_0:
-    mov ecx, 0x1
-    mov edx, 0x1
+    mov ecx, 0x00000001
+    mov edx, 0x00000001
     and ecx, edx
     cmp ecx, 0x00
     sete al
@@ -170,8 +170,8 @@ BB_0:
             var expected = $@"
 ; Test::Method
 LB_0:
-    mov ecx, 0x2A
-    mov edx, 0x64
+    mov ecx, 0x0000002A
+    mov edx, 0x00000064
     mov eax, ecx
     {expectedAsmOp} eax, edx
     {expectedAsmOp} eax, ecx
@@ -262,8 +262,8 @@ BB_0:
             var expected = $@"
 ; Test::Method
 LB_0:
-    mov ecx, 0x2A
-    mov edx, 0x64
+    mov ecx, 0x0000002A
+    mov edx, 0x00000064
     mov eax, ecx
     {expectedAsmOp} eax, edx
     mov r8d, ecx
@@ -299,7 +299,7 @@ BB_0:
             var expected = $@"
 ; Test::Method
 LB_0:
-    mov ecx, 0x2B
+    mov ecx, 0x0000002B
     mov edx, ecx
     {expectedAsmOp} edx
     {expectedAsmOp} ecx
@@ -329,8 +329,8 @@ BB_0:
             const string expected = @"
 ; Test::Method
 LB_0:
-    mov ecx, 0x2A
-    mov r8d, 0xA
+    mov ecx, 0x0000002A
+    mov r8d, 0x0000000A
     mov eax, ecx
     cdq
     idiv r8d
@@ -357,8 +357,8 @@ BB_0:
             const string expected = @"
 ; Test::Method
 LB_0:
-    mov ecx, 0x2A
-    mov r8d, 0xA
+    mov ecx, 0x0000002A
+    mov r8d, 0x0000000A
     mov eax, ecx
     cdq
     idiv r8d
@@ -399,8 +399,8 @@ BB_0:
             var expected = $@"
 ; Test::Method
 LB_0:
-    mov eax, 0x2B
-    mov edx, 0x11
+    mov eax, 0x0000002B
+    mov edx, 0x00000011
     mov ecx, edx
     mov r8d, eax
     {expectedAsmOp} r8d, cl

--- a/test/Cle.CodeGeneration.UnitTests/X64CodeGenerator/VariableTests.cs
+++ b/test/Cle.CodeGeneration.UnitTests/X64CodeGenerator/VariableTests.cs
@@ -164,6 +164,31 @@ LB_0:
 ";
             EmitAndAssertDisassembly(source, expected);
         }
+
+        [TestCase("Add", "add")]
+        [TestCase("Subtract", "sub")]
+        [TestCase("Multiply", "imul")]
+        public void Basic_int32_arithmetic_with_immediate_right(string highOp, string expectedAsmOp)
+        {
+            // private int32 F(int32 value) { return value {op} 7; }
+            var source = $@"
+; #0   int32 param
+; #1   int32
+; #2   int32
+BB_0:
+    Load 7 -> #1
+    {highOp} #0 ? #1 -> #2
+    Return #2
+";
+            var expected = $@"
+; Test::Method
+LB_0:
+    {expectedAsmOp} ecx, 0x7
+    mov eax, ecx
+    ret
+";
+            EmitAndAssertDisassembly(source, expected);
+        }
         
         [TestCase("Subtract", "sub")]
         public void Basic_non_commutative_int32_arithmetic(string highOp, string expectedAsmOp)
@@ -206,7 +231,7 @@ LB_0:
 ";
             EmitAndAssertDisassembly(source, expected);
         }
-        
+
         [TestCase("ArithmeticNegate", "neg")]
         [TestCase("BitwiseNot", "not")]
         public void Basic_unary_int32_arithmetic(string highOp, string expectedAsmOp)

--- a/test/Cle.CodeGeneration.UnitTests/X64CodeGenerator/VariableTests.cs
+++ b/test/Cle.CodeGeneration.UnitTests/X64CodeGenerator/VariableTests.cs
@@ -28,24 +28,20 @@ LB_0:
         [TestCase("LessOrEqual", "setle")]
         public void Bool_assignment_via_comparison(string highOp, string expectedLowOp)
         {
-            // int32 a = 42;
-            // int32 b = 100;
-            // return a op b;
+            // private bool Fun(int32 a, int32 b) {
+            //   return a op b;
+            // }
             var source = $@"
-; #0   int32
-; #1   int32
+; #0   int32 param
+; #1   int32 param
 ; #2   bool
 BB_0:
-    Load 42 -> #0
-    Load 100 -> #1
     {highOp} #0 ?? #1 -> #2
     Return #2
 ";
             var expected = $@"
 ; Test::Method
 LB_0:
-    mov ecx, 0x2A
-    mov edx, 0x64
     cmp ecx, edx
     {expectedLowOp} al
     movzx eax, al
@@ -59,17 +55,15 @@ LB_0:
         [TestCase("LessOrEqual", "setg")]
         public void Bool_assignment_via_inverted_comparison(string highOp, string expectedLowOp)
         {
-            // int32 a = 42;
-            // int32 b = 100;
-            // return a op b;
+            // private bool Fun(int32 a, int32 b) {
+            //   return a op b;
+            // }
             var source = $@"
-; #0   int32
-; #1   int32
+; #0   int32 param
+; #1   int32 param
 ; #2   bool
 ; #3   bool
 BB_0:
-    Load 42 -> #0
-    Load 100 -> #1
     {highOp} #0 ?? #1 -> #2
     BitwiseNot #2 -> #3
     Return #3
@@ -77,8 +71,6 @@ BB_0:
             var expected = $@"
 ; Test::Method
 LB_0:
-    mov ecx, 0x2A
-    mov edx, 0x64
     cmp ecx, edx
     {expectedLowOp} al
     movzx eax, al
@@ -88,9 +80,36 @@ LB_0:
         }
 
         [Test]
+        public void Bool_assignment_via_constant_comparison()
+        {
+            // private bool Fun(int32 a) {
+            //   return a >= 42;
+            // }
+            var source = $@"
+; #0   int32 param
+; #1   int32
+; #2   bool
+; #3   bool
+BB_0:
+    Load 42 -> #1
+    Less #0 >= #1 -> #2
+    BitwiseNot #2 -> #3
+    Return #3
+";
+            var expected = $@"
+; Test::Method
+LB_0:
+    cmp ecx, 0x2A
+    setge al
+    movzx eax, al
+    ret
+";
+            EmitAndAssertDisassembly(source, expected);
+        }
+
+        [Test]
         public void Bool_arithmetic_and_comparison()
         {
-            // return 42;
             const string source = @"
 ; #0   bool
 ; #1   bool
@@ -111,8 +130,7 @@ LB_0:
     mov ecx, 0x1
     mov edx, 0x1
     and ecx, edx
-    xor edx, edx
-    cmp ecx, edx
+    cmp ecx, 0x00
     sete al
     movzx eax, al
     ret
@@ -185,7 +203,7 @@ BB_0:
             var expected = $@"
 ; Test::Method
 LB_0:
-    {expectedAsmOp} ecx, 0x7
+    {expectedAsmOp} ecx, 0x07
     mov eax, ecx
     ret
 ";
@@ -209,7 +227,7 @@ BB_0:
             var expected = $@"
 ; Test::Method
 LB_0:
-    {expectedAsmOp} ecx, 0x7
+    {expectedAsmOp} ecx, 0x07
     mov eax, ecx
     ret
 ";

--- a/test/Cle.CodeGeneration.UnitTests/X64EmitterTests.cs
+++ b/test/Cle.CodeGeneration.UnitTests/X64EmitterTests.cs
@@ -260,6 +260,30 @@ namespace Cle.CodeGeneration.UnitTests
         }
 
         [Test]
+        public void EmitCmpWithImmediate_emits_64_bit_compare_with_byte_immediate()
+        {
+            GetEmitter(out var stream, out var disassembly).EmitCmpWithImmediate(
+                new StorageLocation<X64Register>(X64Register.Rax),
+                -1,
+                8);
+
+            CollectionAssert.AreEqual(new byte[] { 0x48, 0x83, 0xF8, 0xFF }, stream.ToArray());
+            Assert.That(disassembly.ToString().Trim(), Is.EqualTo("cmp rax, 0xFF"));
+        }
+
+        [Test]
+        public void EmitCmpWithImmediate_emits_32_bit_compare_with_dword_immediate()
+        {
+            GetEmitter(out var stream, out var disassembly).EmitCmpWithImmediate(
+                new StorageLocation<X64Register>(X64Register.Rbp),
+                0x12345678,
+                4);
+
+            CollectionAssert.AreEqual(new byte[] { 0x81, 0xFD, 0x78, 0x56, 0x34, 0x12 }, stream.ToArray());
+            Assert.That(disassembly.ToString().Trim(), Is.EqualTo("cmp ebp, 0x12345678"));
+        }
+
+        [Test]
         public void EmitTest_emits_32_bit_logical_compare_between_basic_and_new_registers()
         {
             GetEmitter(out var stream, out var disassembly).EmitTest(
@@ -533,7 +557,7 @@ namespace Cle.CodeGeneration.UnitTests
                 4);
 
             CollectionAssert.AreEqual(new byte[] { 0x83, 0xC0, 0xFF }, stream.ToArray());
-            Assert.That(disassembly.ToString().Trim(), Is.EqualTo("add eax, 0xFFFFFFFFFFFFFFFF"));
+            Assert.That(disassembly.ToString().Trim(), Is.EqualTo("add eax, 0xFF"));
         }
 
         [Test]
@@ -546,7 +570,7 @@ namespace Cle.CodeGeneration.UnitTests
                 4);
 
             CollectionAssert.AreEqual(new byte[] { 0x41, 0x81, 0xC1, 0x0D, 0xF0, 0xDD, 0x00 }, stream.ToArray());
-            Assert.That(disassembly.ToString().Trim(), Is.EqualTo("add r9d, 0xDDF00D"));
+            Assert.That(disassembly.ToString().Trim(), Is.EqualTo("add r9d, 0x00DDF00D"));
         }
 
         [Test]
@@ -572,7 +596,7 @@ namespace Cle.CodeGeneration.UnitTests
                 4);
 
             CollectionAssert.AreEqual(new byte[] { 0x41, 0x81, 0xED, 0xCC, 0xED, 0xFF, 0xFF }, stream.ToArray());
-            Assert.That(disassembly.ToString().Trim(), Is.EqualTo("sub r13d, 0xFFFFFFFFFFFFEDCC"));
+            Assert.That(disassembly.ToString().Trim(), Is.EqualTo("sub r13d, 0xFFFFEDCC"));
         }
 
         [Test]
@@ -598,7 +622,7 @@ namespace Cle.CodeGeneration.UnitTests
                 8);
 
             CollectionAssert.AreEqual(new byte[] { 0x48, 0x69, 0xD2, 0x34, 0x12, 0x00, 0x00 }, stream.ToArray());
-            Assert.That(disassembly.ToString().Trim(), Is.EqualTo("imul rdx, 0x1234"));
+            Assert.That(disassembly.ToString().Trim(), Is.EqualTo("imul rdx, 0x00001234"));
         }
 
         [Test]
@@ -623,7 +647,7 @@ namespace Cle.CodeGeneration.UnitTests
                 4);
 
             CollectionAssert.AreEqual(new byte[] { 0xC1, 0xE2, 0x07 }, stream.ToArray());
-            Assert.That(disassembly.ToString().Trim(), Is.EqualTo("shl edx, 0x7"));
+            Assert.That(disassembly.ToString().Trim(), Is.EqualTo("shl edx, 0x07"));
         }
 
         [Test]

--- a/test/Cle.CodeGeneration.UnitTests/X64EmitterTests.cs
+++ b/test/Cle.CodeGeneration.UnitTests/X64EmitterTests.cs
@@ -45,7 +45,7 @@ namespace Cle.CodeGeneration.UnitTests
                 0x18);
 
             CollectionAssert.AreEqual(new byte[] { 0xBA, 0x18, 0x00, 0x00, 0x00 }, stream.ToArray());
-            Assert.That(disassembly.ToString().Trim(), Is.EqualTo("mov edx, 0x18"));
+            Assert.That(disassembly.ToString().Trim(), Is.EqualTo("mov edx, 0x00000018"));
         }
 
         [Test]
@@ -80,6 +80,30 @@ namespace Cle.CodeGeneration.UnitTests
             CollectionAssert.AreEqual(new byte[] { 0x49, 0xBF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F },
                 stream.ToArray());
             Assert.That(disassembly.ToString().Trim(), Is.EqualTo("mov r15, 0x7FFFFFFFFFFFFFFF"));
+        }
+
+        [Test]
+        public void EmitLoad_emits_sign_extended_32_bit_load()
+        {
+            GetEmitter(out var stream, out var disassembly).EmitLoad(
+                new StorageLocation<X64Register>(X64Register.Rax),
+                unchecked((ulong)-1));
+
+            CollectionAssert.AreEqual(new byte[] { 0x48, 0xC7, 0xC0, 0xFF, 0xFF, 0xFF, 0xFF },
+                stream.ToArray());
+            Assert.That(disassembly.ToString().Trim(), Is.EqualTo("mov rax, 0xFFFFFFFF"));
+        }
+
+        [Test]
+        public void EmitLoad_emits_sign_extended_32_bit_load_to_new_register()
+        {
+            GetEmitter(out var stream, out var disassembly).EmitLoad(
+                new StorageLocation<X64Register>(X64Register.R10),
+                unchecked((ulong)-1234));
+
+            CollectionAssert.AreEqual(new byte[] { 0x49, 0xC7, 0xC2, 0x2E, 0xFB, 0xFF, 0xFF },
+                stream.ToArray());
+            Assert.That(disassembly.ToString().Trim(), Is.EqualTo("mov r10, 0xFFFFFB2E"));
         }
 
         [Test]

--- a/test/Cle.CodeGeneration.UnitTests/X64EmitterTests.cs
+++ b/test/Cle.CodeGeneration.UnitTests/X64EmitterTests.cs
@@ -511,7 +511,7 @@ namespace Cle.CodeGeneration.UnitTests
         }
 
         [Test]
-        public void EmitGeneralBinaryWithImmediate_emits_8_bit_stack_add()
+        public void EmitGeneralBinaryWithImmediate_emits_64_bit_stack_add_with_byte_immediate()
         {
             GetEmitter(out var stream, out var disassembly).EmitGeneralBinaryWithImmediate(
                 BinaryOp.Add,
@@ -524,7 +524,33 @@ namespace Cle.CodeGeneration.UnitTests
         }
 
         [Test]
-        public void EmitGeneralBinaryWithImmediate_emits_8_bit_stack_sub()
+        public void EmitGeneralBinaryWithImmediate_emits_32_bit_add_with_negative_byte_immediate()
+        {
+            GetEmitter(out var stream, out var disassembly).EmitGeneralBinaryWithImmediate(
+                BinaryOp.Add,
+                new StorageLocation<X64Register>(X64Register.Rax),
+                -1,
+                4);
+
+            CollectionAssert.AreEqual(new byte[] { 0x83, 0xC0, 0xFF }, stream.ToArray());
+            Assert.That(disassembly.ToString().Trim(), Is.EqualTo("add eax, 0xFFFFFFFFFFFFFFFF"));
+        }
+
+        [Test]
+        public void EmitGeneralBinaryWithImmediate_emits_32_bit_add_with_dword_immediate()
+        {
+            GetEmitter(out var stream, out var disassembly).EmitGeneralBinaryWithImmediate(
+                BinaryOp.Add,
+                new StorageLocation<X64Register>(X64Register.R9),
+                0x0DDF00D,
+                4);
+
+            CollectionAssert.AreEqual(new byte[] { 0x41, 0x81, 0xC1, 0x0D, 0xF0, 0xDD, 0x00 }, stream.ToArray());
+            Assert.That(disassembly.ToString().Trim(), Is.EqualTo("add r9d, 0xDDF00D"));
+        }
+
+        [Test]
+        public void EmitGeneralBinaryWithImmediate_emits_64_bit_stack_sub_with_byte_immediate()
         {
             GetEmitter(out var stream, out var disassembly).EmitGeneralBinaryWithImmediate(
                 BinaryOp.Subtract,
@@ -534,6 +560,45 @@ namespace Cle.CodeGeneration.UnitTests
 
             CollectionAssert.AreEqual(new byte[] { 0x48, 0x83, 0xEC, 0x20 }, stream.ToArray());
             Assert.That(disassembly.ToString().Trim(), Is.EqualTo("sub rsp, 0x20"));
+        }
+
+        [Test]
+        public void EmitGeneralBinaryWithImmediate_emits_32_bit_sub_with_dword_immediate()
+        {
+            GetEmitter(out var stream, out var disassembly).EmitGeneralBinaryWithImmediate(
+                BinaryOp.Subtract,
+                new StorageLocation<X64Register>(X64Register.R13),
+                -0x1234,
+                4);
+
+            CollectionAssert.AreEqual(new byte[] { 0x41, 0x81, 0xED, 0xCC, 0xED, 0xFF, 0xFF }, stream.ToArray());
+            Assert.That(disassembly.ToString().Trim(), Is.EqualTo("sub r13d, 0xFFFFFFFFFFFFEDCC"));
+        }
+
+        [Test]
+        public void EmitGeneralBinaryWithImmediate_emits_64_bit_imul_with_byte_immediate()
+        {
+            GetEmitter(out var stream, out var disassembly).EmitGeneralBinaryWithImmediate(
+                BinaryOp.Multiply,
+                new StorageLocation<X64Register>(X64Register.Rdx),
+                0x12,
+                8);
+
+            CollectionAssert.AreEqual(new byte[] { 0x48, 0x6B, 0xD2, 0x12 }, stream.ToArray());
+            Assert.That(disassembly.ToString().Trim(), Is.EqualTo("imul rdx, 0x12"));
+        }
+
+        [Test]
+        public void EmitGeneralBinaryWithImmediate_emits_64_bit_imul_with_dword_immediate()
+        {
+            GetEmitter(out var stream, out var disassembly).EmitGeneralBinaryWithImmediate(
+                BinaryOp.Multiply,
+                new StorageLocation<X64Register>(X64Register.Rdx),
+                0x1234,
+                8);
+
+            CollectionAssert.AreEqual(new byte[] { 0x48, 0x69, 0xD2, 0x34, 0x12, 0x00, 0x00 }, stream.ToArray());
+            Assert.That(disassembly.ToString().Trim(), Is.EqualTo("imul rdx, 0x1234"));
         }
 
         [Test]

--- a/test/Cle.CodeGeneration.UnitTests/X64EmitterTests.cs
+++ b/test/Cle.CodeGeneration.UnitTests/X64EmitterTests.cs
@@ -614,6 +614,19 @@ namespace Cle.CodeGeneration.UnitTests
         }
 
         [Test]
+        public void EmitShiftWithImmediate_emits_32_bit_left_shift_of_basic_register()
+        {
+            GetEmitter(out var stream, out var disassembly).EmitShiftWithImmediate(
+                ShiftType.Left,
+                new StorageLocation<X64Register>(X64Register.Rdx),
+                7,
+                4);
+
+            CollectionAssert.AreEqual(new byte[] { 0xC1, 0xE2, 0x07 }, stream.ToArray());
+            Assert.That(disassembly.ToString().Trim(), Is.EqualTo("shl edx, 0x7"));
+        }
+
+        [Test]
         public void EmitShift_emits_64_bit_arithmetic_right_shift_of_new_register()
         {
             GetEmitter(out var stream, out var disassembly).EmitShift(
@@ -623,6 +636,19 @@ namespace Cle.CodeGeneration.UnitTests
 
             CollectionAssert.AreEqual(new byte[] { 0x49, 0xD3, 0xF8 }, stream.ToArray());
             Assert.That(disassembly.ToString().Trim(), Is.EqualTo("sar r8, cl"));
+        }
+
+        [Test]
+        public void EmitShiftWithImmediate_emits_64_bit_arithmetic_right_shift_of_new_register()
+        {
+            GetEmitter(out var stream, out var disassembly).EmitShiftWithImmediate(
+                ShiftType.ArithmeticRight,
+                new StorageLocation<X64Register>(X64Register.R8),
+                17,
+                8);
+
+            CollectionAssert.AreEqual(new byte[] { 0x49, 0xC1, 0xF8, 0x11 }, stream.ToArray());
+            Assert.That(disassembly.ToString().Trim(), Is.EqualTo("sar r8, 0x11"));
         }
 
         [Test]

--- a/test/Cle.IntegrationTests/CodeGenBringUpTests.cs
+++ b/test/Cle.IntegrationTests/CodeGenBringUpTests.cs
@@ -22,6 +22,7 @@ namespace Cle.IntegrationTests
         [TestCase("ReturnInt", 42)]
         [TestCase("ReturnParameter", 100)]
         [TestCase("RotateInt32", 10)]
+        [TestCase("RotateInt32ByConstant", 10)]
         [TestCase("SimpleForwardPhi", 50)]
         [TestCase("SimpleWhileLoop", 45)]
         [TestCase("SimpleWhileLoop2", 36)]

--- a/test/Cle.IntegrationTests/TestCases/CodeGenBringUp/RotateInt32ByConstant/RotateInt32.cle
+++ b/test/Cle.IntegrationTests/TestCases/CodeGenBringUp/RotateInt32ByConstant/RotateInt32.cle
@@ -1,0 +1,18 @@
+// This test verifies int32 shift operators with constant arguments.
+// Since the integer type is signed, this algorithm is incorrect for negative values.
+//
+// Expected return code: 10.
+// No console output expected.
+
+namespace Rotate::Int32::ByConstant;
+
+[EntryPoint]
+public int32 Main()
+{
+    return RotateLeftBy3(1073741825); // 0x4000_0001 rotated by 3 is 0xA
+}
+
+private int32 RotateLeftBy3(int32 value)
+{
+    return (value << 3) | (value >> (32 - 3));
+}


### PR DESCRIPTION
Fixes #64, contributes to #52.

- Constant right-hand operands of the `add`, `sub`, `imul`, `shl`, `sar` and `cmp` x64 operations are now stored as immediates instead of using a temporary register
- For commutative operations `add` and `imul`, the same applies to left-hand operands too
- Added the "32-bit immediate sign-extended to 64 bits" form of `mov`
- In disassembly, immediates are now fixed-width hexadecimal values
- Cleaned up `PeepholeOptimizer` a bit

Filing a follow-up issue for using immediates in the bit operations.