### PR TITLE
Update .Net Core 3.1, enable Coverlet code coverage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,34 +14,25 @@ variables:
   configuration: 'Release'
 
 steps:
-- task: UseDotNet@2
-  inputs:
-    version: '3.0.x'
-  displayName: 'Install .NET Core 3.0 SDK'
-- task: UseDotNet@2
-  inputs:
-    version: '2.1.x'
-    packageType: runtime
-  displayName: 'Install .NET Core 2.1 runtime for SonarScanner'
 - script: |
     dotnet tool install --tool-path . nbgv
     .\nbgv cloud
   displayName: 'Install NerdBank.GitVersioning'
 - script: |
     dotnet tool install --tool-path . dotnet-sonarscanner
-    .\dotnet-sonarscanner begin /k:"polsys_cle" /v:"$(Build.BuildNumber)" /o:"polsys-github" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.login="$(SONAR_TOKEN)" /d:sonar.pullrequest.key=$(System.PullRequest.PullRequestNumber) /d:sonar.pullrequest.branch="$(Build.SourceBranch)" /d:sonar.pullrequest.base="$(System.PullRequest.TargetBranch)"
+    .\dotnet-sonarscanner begin /k:"polsys_cle" /v:"$(Build.BuildNumber)" /o:"polsys-github" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.login="$(SONAR_TOKEN)" /d:sonar.pullrequest.key=$(System.PullRequest.PullRequestNumber) /d:sonar.pullrequest.branch="$(Build.SourceBranch)" /d:sonar.pullrequest.base="$(System.PullRequest.TargetBranch)" /d:sonar.cs.opencover.reportsPaths="**/*.opencover.xml"
   condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
   displayName: 'Install SonarScanner (PR)'
 - script: |
     dotnet tool install --tool-path . dotnet-sonarscanner
-    .\dotnet-sonarscanner begin /k:"polsys_cle" /v:"$(Build.BuildNumber)" /o:"polsys-github" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.login="$(SONAR_TOKEN)"
+    .\dotnet-sonarscanner begin /k:"polsys_cle" /v:"$(Build.BuildNumber)" /o:"polsys-github" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.login="$(SONAR_TOKEN)" /d:sonar.cs.opencover.reportsPaths="**/*.opencover.xml"
   condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
   displayName: 'Install SonarScanner (CI)'
 - script: |
     dotnet build --configuration $(configuration)
   displayName: 'Build Release'
 - script: |
-    dotnet test --configuration $(configuration) --no-build --logger trx --collect "Code Coverage" --filter "FullyQualifiedName~UnitTests"
+    dotnet test --configuration $(configuration) --no-build --logger trx --collect "XPlat Code Coverage" --settings coverlet.runsettings --filter "FullyQualifiedName~UnitTests"
   displayName: 'Run unit tests'
 - script: |
     dotnet test --configuration Release --no-build --logger trx test/Cle.IntegrationTests/Cle.IntegrationTests.csproj

--- a/coverlet.runsettings
+++ b/coverlet.runsettings
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <Format>opencover</Format>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/src/Cle.Frontend/Cle.Frontend.csproj
+++ b/src/Cle.Frontend/Cle.Frontend.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <AssemblyName>cle</AssemblyName>

--- a/test/Cle.Benchmarks/Cle.Benchmarks.csproj
+++ b/test/Cle.Benchmarks/Cle.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/test/Cle.CodeGeneration.UnitTests/Cle.CodeGeneration.UnitTests.csproj
+++ b/test/Cle.CodeGeneration.UnitTests/Cle.CodeGeneration.UnitTests.csproj
@@ -1,17 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>8.0</LangVersion>
-    <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
-  </ItemGroup>
+  <Import Project="..\Tests.targets" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Cle.CodeGeneration\Cle.CodeGeneration.csproj" />

--- a/test/Cle.CodeGeneration.UnitTests/Cle.CodeGeneration.UnitTests.csproj
+++ b/test/Cle.CodeGeneration.UnitTests/Cle.CodeGeneration.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/test/Cle.Compiler.UnitTests/Cle.Compiler.UnitTests.csproj
+++ b/test/Cle.Compiler.UnitTests/Cle.Compiler.UnitTests.csproj
@@ -1,17 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>8.0</LangVersion>
-    <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
-  </ItemGroup>
+  <Import Project="..\Tests.targets" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Cle.Compiler\Cle.Compiler.csproj" />

--- a/test/Cle.Compiler.UnitTests/Cle.Compiler.UnitTests.csproj
+++ b/test/Cle.Compiler.UnitTests/Cle.Compiler.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/test/Cle.Frontend.UnitTests/Cle.Frontend.UnitTests.csproj
+++ b/test/Cle.Frontend.UnitTests/Cle.Frontend.UnitTests.csproj
@@ -1,17 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>8.0</LangVersion>
-    <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
-  </ItemGroup>
+  <Import Project="..\Tests.targets" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Cle.Frontend\Cle.Frontend.csproj" />

--- a/test/Cle.Frontend.UnitTests/Cle.Frontend.UnitTests.csproj
+++ b/test/Cle.Frontend.UnitTests/Cle.Frontend.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/test/Cle.IntegrationTests/Cle.IntegrationTests.csproj
+++ b/test/Cle.IntegrationTests/Cle.IntegrationTests.csproj
@@ -1,17 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>8.0</LangVersion>
-    <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
-  </ItemGroup>
+  <Import Project="..\Tests.targets" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Cle.Common\Cle.Common.csproj" />

--- a/test/Cle.IntegrationTests/Cle.IntegrationTests.csproj
+++ b/test/Cle.IntegrationTests/Cle.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/test/Cle.IntegrationTests/TestRunner.cs
+++ b/test/Cle.IntegrationTests/TestRunner.cs
@@ -23,8 +23,9 @@ namespace Cle.IntegrationTests
         /// <param name="modulePath">Path relative to the integration test assembly.</param>
         public TestRunner(string modulePath)
         {
+            // GetDirectoryName can return null, but hope it never does
             _absoluteModulePath = Path.GetFullPath(modulePath, 
-                Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
+                Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!);
         }
 
         public TestRunner WithDisassembly()

--- a/test/Cle.Parser.UnitTests/Cle.Parser.UnitTests.csproj
+++ b/test/Cle.Parser.UnitTests/Cle.Parser.UnitTests.csproj
@@ -1,17 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>8.0</LangVersion>
-    <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
-  </ItemGroup>
+  <Import Project="..\Tests.targets" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Cle.Common\Cle.Common.csproj" />

--- a/test/Cle.Parser.UnitTests/Cle.Parser.UnitTests.csproj
+++ b/test/Cle.Parser.UnitTests/Cle.Parser.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/test/Cle.SemanticAnalysis.UnitTests/Cle.SemanticAnalysis.UnitTests.csproj
+++ b/test/Cle.SemanticAnalysis.UnitTests/Cle.SemanticAnalysis.UnitTests.csproj
@@ -1,17 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>8.0</LangVersion>
-    <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
-  </ItemGroup>
+  <Import Project="..\Tests.targets" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Cle.SemanticAnalysis\Cle.SemanticAnalysis.csproj" />

--- a/test/Cle.SemanticAnalysis.UnitTests/Cle.SemanticAnalysis.UnitTests.csproj
+++ b/test/Cle.SemanticAnalysis.UnitTests/Cle.SemanticAnalysis.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/test/Cle.UnitTests.Common/Cle.UnitTests.Common.csproj
+++ b/test/Cle.UnitTests.Common/Cle.UnitTests.Common.csproj
@@ -1,15 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>8.0</LangVersion>
-    <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="nunit" Version="3.12.0" />
-  </ItemGroup>
+  <Import Project="..\Tests.targets" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Cle.Common\Cle.Common.csproj" />

--- a/test/Cle.UnitTests.Common/Cle.UnitTests.Common.csproj
+++ b/test/Cle.UnitTests.Common/Cle.UnitTests.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/test/Tests.targets
+++ b/test/Tests.targets
@@ -11,6 +11,10 @@
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/test/Tests.targets
+++ b/test/Tests.targets
@@ -1,0 +1,16 @@
+<Project>
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Fixes #83 and #72.

- Updated executable projects to `netcoreapp3.1`
- Refactored common test project properties into a `.targets` file
- Took Coverlet code coverage package into use, and coerced Sonar to use it

~Still WIP, let's see if it builds.~ It worked on the first try?! 😮